### PR TITLE
fix(#42): 물품 검색 API 응답에 status 필드 추가

### DIFF
--- a/src/main/java/com/eod/eod/domain/item/application/ItemSearchService.java
+++ b/src/main/java/com/eod/eod/domain/item/application/ItemSearchService.java
@@ -86,6 +86,7 @@ public class ItemSearchService {
                 .foundPlace(placeMap.getOrDefault(item.getFoundPlaceId(), ""))
                 .placeDetail(item.getFoundPlaceDetail())
                 .thumbnailUrl(item.getImage())
+                .status(item.getStatus().name())
                 .build();
     }
 }

--- a/src/main/java/com/eod/eod/domain/item/presentation/dto/ItemSummaryResponse.java
+++ b/src/main/java/com/eod/eod/domain/item/presentation/dto/ItemSummaryResponse.java
@@ -37,4 +37,7 @@ public class ItemSummaryResponse {
     @JsonProperty("thumbnail_url")
     @Schema(description = "썸네일 이미지 URL", example = "")
     private String thumbnailUrl;
+
+    @Schema(description = "물품 상태", example = "LOST", allowableValues = {"LOST", "TO_BE_DISCARDED", "DISCARDED", "GIVEN"})
+    private String status;
 }


### PR DESCRIPTION
## Summary
- ItemSummaryResponse DTO에 누락된 `status` 필드를 추가했습니다
- ItemSearchService의 `toSummaryDto` 메서드에서 status 값을 매핑하도록 수정했습니다

## Details
### 문제점
`GET /items/search` API 응답의 각 item 객체에 `status` 필드가 누락되어 있었습니다.
- DB와 Entity(Item.java:44-45)에는 ItemStatus ENUM이 존재
- DTO 변환 과정(ItemSearchService.java:81-89)에서 status 필드가 누락

### 해결 방법
1. **ItemSummaryResponse.java** - status 필드 추가
   - 타입: String (ENUM을 문자열로 변환)
   - 가능한 값: LOST, TO_BE_DISCARDED, DISCARDED, GIVEN
   - Swagger 문서에도 반영

2. **ItemSearchService.java** - toSummaryDto 메서드 수정
   - `.status(item.getStatus().name())` 추가
   - ENUM → String 변환 (프로젝트 컨벤션 준수)

### 변경된 파일
- `src/main/java/com/eod/eod/domain/item/presentation/dto/ItemSummaryResponse.java`
- `src/main/java/com/eod/eod/domain/item/application/ItemSearchService.java`

## Test Plan
- [ ] GET /items/search?page=1&size=10&status=LOST 호출 시 응답의 content 배열 내 각 객체에 status 필드 존재 확인
- [ ] status 값이 "LOST", "TO_BE_DISCARDED", "DISCARDED", "GIVEN" 중 하나인지 확인
- [ ] 기존 필드들(id, name, found_date, found_place 등)이 정상적으로 반환되는지 확인
- [ ] Swagger 문서에서 status 필드가 정상적으로 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)