### PR TITLE
feat(#44): 폐기 예정 물품 개수 조회 API 추가

### DIFF
--- a/src/main/java/com/eod/eod/domain/item/application/DisposalCountService.java
+++ b/src/main/java/com/eod/eod/domain/item/application/DisposalCountService.java
@@ -1,0 +1,19 @@
+package com.eod.eod.domain.item.application;
+
+import com.eod.eod.domain.item.infrastructure.ItemRepository;
+import com.eod.eod.domain.item.model.Item;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DisposalCountService {
+
+    private final ItemRepository itemRepository;
+
+    public long getDisposalCount() {
+        return itemRepository.countByStatus(Item.ItemStatus.TO_BE_DISCARDED);
+    }
+}

--- a/src/main/java/com/eod/eod/domain/item/infrastructure/ItemRepository.java
+++ b/src/main/java/com/eod/eod/domain/item/infrastructure/ItemRepository.java
@@ -21,4 +21,7 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
 
     // 장기 방치된 분실물 조회 (자동 폐기 예정 전환용)
     List<Item> findByStatusAndFoundAtBefore(Item.ItemStatus status, LocalDateTime dateTime);
+
+    // 특정 상태의 물품 개수 조회
+    long countByStatus(Item.ItemStatus status);
 }

--- a/src/main/java/com/eod/eod/domain/item/presentation/dto/DisposalCountResponse.java
+++ b/src/main/java/com/eod/eod/domain/item/presentation/dto/DisposalCountResponse.java
@@ -1,0 +1,18 @@
+package com.eod.eod.domain.item.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "폐기 예정 물품 개수 응답")
+public class DisposalCountResponse {
+
+    @Schema(description = "폐기 예정 물품 개수", example = "12")
+    private long count;
+
+    public static DisposalCountResponse of(long count) {
+        return new DisposalCountResponse(count);
+    }
+}


### PR DESCRIPTION
## Summary
- 대시보드에서 폐기 예정 물품의 총 건수를 조회할 수 있는 전용 API를 추가했습니다
- GET /items/disposal/count 엔드포인트 구현
- ADMIN 권한 필수

## Details

### 엔드포인트 명세
- **Method**: GET
- **Path**: `/items/disposal/count`
- **권한**: ADMIN만 접근 가능
- **Response Body**:
  ```json
  {
    "count": 12
  }
  ```

### 구현 내용
1. **ItemRepository.java** - countByStatus 메서드 추가
   - Spring Data JPA의 파생 쿼리 메서드 활용
   - 특정 상태(TO_BE_DISCARDED)의 물품 개수만 조회

2. **DisposalCountService.java** - 신규 생성
   - 폐기 예정 상태의 물품 개수를 조회하는 로직
   - `@Transactional(readOnly = true)` 적용

3. **DisposalCountResponse.java** - 신규 생성
   - { "count": number } 형태의 응답 DTO
   - Swagger 문서 포함

4. **ItemController.java** - 엔드포인트 추가
   - ADMIN 권한 체크 (currentUser.isAdmin())
   - 401/500 에러 처리 포함
   - Swagger 문서 완비

### 변경된 파일
- `src/main/java/com/eod/eod/domain/item/infrastructure/ItemRepository.java`
- `src/main/java/com/eod/eod/domain/item/application/DisposalCountService.java` (신규)
- `src/main/java/com/eod/eod/domain/item/presentation/dto/DisposalCountResponse.java` (신규)
- `src/main/java/com/eod/eod/domain/item/presentation/ItemController.java`

### 오류 처리
- **401 Unauthorized**: ADMIN 권한 없을 때
- **500 Internal Server Error**: 서버 내부 오류 발생 시

## Test Plan
- [ ] ADMIN 사용자로 GET /items/disposal/count 호출 시 정상 응답 확인
- [ ] 폐기 예정 물품이 12개일 때 `{ "count": 12 }` 반환 확인
- [ ] 비ADMIN 사용자 호출 시 401 에러 반환 확인
- [ ] Swagger 문서에서 API 정상 표시 확인

## API 호출 예시
```bash
# 성공 케이스
curl -X GET "http://localhost:8080/items/disposal/count" \
  -H "Authorization: Bearer {ADMIN_TOKEN}"

# 응답
{
  "count": 12
}

# 실패 케이스 (권한 없음)
# 응답: 401 Unauthorized
{
  "message": "ADMIN 권한이 필요합니다."
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)