### PR TITLE
feat(#45): 회수 신청 건수 조회 API 추가

### DIFF
--- a/src/main/java/com/eod/eod/domain/item/application/ClaimCountService.java
+++ b/src/main/java/com/eod/eod/domain/item/application/ClaimCountService.java
@@ -1,0 +1,19 @@
+package com.eod.eod.domain.item.application;
+
+import com.eod.eod.domain.item.infrastructure.ItemClaimRepository;
+import com.eod.eod.domain.item.model.ItemClaim;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ClaimCountService {
+
+    private final ItemClaimRepository itemClaimRepository;
+
+    public long getClaimCount() {
+        return itemClaimRepository.countByStatus(ItemClaim.ClaimStatus.PENDING);
+    }
+}

--- a/src/main/java/com/eod/eod/domain/item/infrastructure/ItemClaimRepository.java
+++ b/src/main/java/com/eod/eod/domain/item/infrastructure/ItemClaimRepository.java
@@ -7,4 +7,7 @@ public interface ItemClaimRepository extends JpaRepository<ItemClaim, Long> {
 
     // 특정 사용자가 특정 아이템에 대해 이미 소유권 주장을 했는지 확인
     boolean existsByItemIdAndClaimantId(Long itemId, Long claimantId);
+
+    // 특정 상태의 회수 신청 개수 조회
+    long countByStatus(ItemClaim.ClaimStatus status);
 }

--- a/src/main/java/com/eod/eod/domain/item/presentation/dto/ClaimCountResponse.java
+++ b/src/main/java/com/eod/eod/domain/item/presentation/dto/ClaimCountResponse.java
@@ -1,0 +1,18 @@
+package com.eod.eod.domain.item.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "회수 신청 건수 응답")
+public class ClaimCountResponse {
+
+    @Schema(description = "회수 신청 건수", example = "8")
+    private long count;
+
+    public static ClaimCountResponse of(long count) {
+        return new ClaimCountResponse(count);
+    }
+}


### PR DESCRIPTION
## Summary
- 대시보드에서 회수 신청 건수를 즉시 확인할 수 있는 전용 API를 추가했습니다
- GET /items/claims/count 엔드포인트 구현
- ADMIN 권한 필수

## Details

### 엔드포인트 명세
- **Method**: GET
- **Path**: `/items/claims/count`
- **권한**: ADMIN만 접근 가능
- **Response Body**:
  ```json
  {
    "count": 8
  }
  ```

### 구현 내용
1. **ItemClaimRepository.java** - countByStatus 메서드 추가
   - Spring Data JPA의 파생 쿼리 메서드 활용
   - PENDING 상태의 회수 신청 개수만 조회

2. **ClaimCountService.java** - 신규 생성
   - 회수 신청 상태(PENDING)인 아이템 개수 조회 로직
   - `@Transactional(readOnly = true)` 적용

3. **ClaimCountResponse.java** - 신규 생성
   - { "count": number } 형태의 응답 DTO
   - 폐기 예정 건수 API와 동일한 구조
   - Swagger 문서 포함

4. **ItemClaimController.java** - 엔드포인트 추가
   - ADMIN 권한 체크 (currentUser.isAdmin())
   - 401/500 에러 처리 포함
   - Swagger 문서 완비

### 변경된 파일
- `src/main/java/com/eod/eod/domain/item/infrastructure/ItemClaimRepository.java`
- `src/main/java/com/eod/eod/domain/item/application/ClaimCountService.java` (신규)
- `src/main/java/com/eod/eod/domain/item/presentation/dto/ClaimCountResponse.java` (신규)
- `src/main/java/com/eod/eod/domain/item/presentation/ItemClaimController.java`

### 오류 처리
- **401 Unauthorized**: ADMIN 권한 없을 때
- **500 Internal Server Error**: 서버 내부 오류 발생 시

### 일관성 유지
- 폐기 예정 물품 건수 조회 API(GET /items/disposal/count)와 동일한 패턴으로 구현
- 응답 구조 및 상태 코드 패턴 통일
- 대시보드에서 두 API를 함께 호출 가능

## Test Plan
- [ ] ADMIN 사용자로 GET /items/claims/count 호출 시 정상 응답 확인
- [ ] 회수 신청(PENDING)이 8개일 때 `{ "count": 8 }` 반환 확인
- [ ] 비ADMIN 사용자 호출 시 401 에러 반환 확인
- [ ] Swagger 문서에서 API 정상 표시 확인
- [ ] 폐기 예정 건수 API와 함께 호출 시 정상 작동 확인

## API 호출 예시
```bash
# 성공 케이스
curl -X GET "http://localhost:8080/items/claims/count" \
  -H "Authorization: Bearer {ADMIN_TOKEN}"

# 응답
{
  "count": 8
}

# 실패 케이스 (권한 없음)
# 응답: 401 Unauthorized
{
  "message": "ADMIN 권한이 필요합니다."
}
```

## 대시보드 활용 예시
```javascript
// 대시보드에서 두 건수를 동시에 조회
const fetchDashboardCounts = async () => {
  const [disposalCount, claimCount] = await Promise.all([
    fetch('/items/disposal/count'),
    fetch('/items/claims/count')
  ]);
  
  // 폐기 예정: 12건, 회수 신청: 8건 표시
};
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)