### PR TITLE
fix(#46) :: ARM64 호환성 문제 해결 - Alpine에서 Debian JRE로 변경

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,15 +15,15 @@ COPY src src
 # Build application
 RUN gradle bootJar --no-daemon
 
-# Runtime stage with JRE (smaller image)
-FROM eclipse-temurin:17-jre-alpine
+# Runtime stage with JRE (ARM64 compatible)
+FROM eclipse-temurin:17-jre
 WORKDIR /eod
 
 # Copy only the built jar
 COPY --from=build /workspace/build/libs/*.jar app.jar
 
-# Run as non-root user
-RUN addgroup -S spring && adduser -S spring -G spring
+# Run as non-root user (Debian-based)
+RUN groupadd -r spring && useradd -r -g spring spring
 USER spring:spring
 
 ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
- eclipse-temurin:17-jre-alpine은 ARM64 미지원
- eclipse-temurin:17-jre (Debian 기반)로 변경하여 ARM64 호환
- addgroup/adduser 명령어를 groupadd/useradd로 변경 (Debian 기반)

이미지 크기:
- Alpine 목표: 80MB
- Debian JRE 실제: ~120MB (여전히 JDK 150MB보다 20% 작음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 📋 요약
이 PR에서 수행한 작업에 대한 간단한 설명을 작성해주세요.

## 🔗 관련 이슈
close #

## 🔄 변경 사항
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 업데이트
- [ ] 스타일 변경
- [ ] 리팩토링
- [ ] 성능 개선
- [ ] 테스트 추가

### 변경된 내용
변경된 내용에 대한 자세한 설명을 작성해주세요.

### 변경 이유
왜 이러한 변경이 필요했는지 설명해주세요.

## ✅ 체크리스트
- [ ] 코드 리뷰 완료
- [ ] 테스트 통과
- [ ] 문서 업데이트 (필요한 경우)
- [ ] 브레이킹 체인지 확인