### PR TITLE
fix :: JWT 토큰 만료 시 401 응답 반환 및 필터 체인 중단

### DIFF
--- a/src/main/java/com/eod/eod/common/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/eod/eod/common/jwt/JwtTokenProvider.java
@@ -77,7 +77,7 @@ public class JwtTokenProvider {
         } catch (SecurityException | MalformedJwtException e) {
             log.error("잘못된 JWT 서명입니다.", e);
         } catch (ExpiredJwtException e) {
-            log.error("만료된 JWT 토큰입니다.", e);
+            log.debug("만료된 JWT 토큰입니다.", e);
         } catch (UnsupportedJwtException e) {
             log.error("지원되지 않는 JWT 토큰입니다.", e);
         } catch (IllegalArgumentException e) {


### PR DESCRIPTION
- 토큰 만료 시 401 Unauthorized 응답 반환하고 필터 체인 중단
- 컨트롤러에서 NPE 발생 방지
- 만료된 토큰 로그 레벨을 error에서 debug로 변경
- JSON 형식의 명시적인 에러 메시지 제공

## 📋 요약
이 PR에서 수행한 작업에 대한 간단한 설명을 작성해주세요.

## 🔗 관련 이슈
close #

## 🔄 변경 사항
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 업데이트
- [ ] 스타일 변경
- [ ] 리팩토링
- [ ] 성능 개선
- [ ] 테스트 추가

### 변경된 내용
변경된 내용에 대한 자세한 설명을 작성해주세요.

### 변경 이유
왜 이러한 변경이 필요했는지 설명해주세요.

## ✅ 체크리스트
- [ ] 코드 리뷰 완료
- [ ] 테스트 통과
- [ ] 문서 업데이트 (필요한 경우)
- [ ] 브레이킹 체인지 확인