### PR TITLE
fix :: 이미지 업로드 디렉토리 권한 문제 해결

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,13 @@ WORKDIR /eod
 # Copy the prebuilt jar from the workflow
 COPY build/libs/*.jar app.jar
 
+# Create upload directory with proper permissions
+RUN mkdir -p /eod/uploads && \
+    groupadd -r spring && \
+    useradd -r -g spring spring && \
+    chown -R spring:spring /eod
+
 # Run as non-root user (Debian-based)
-RUN groupadd -r spring && useradd -r -g spring spring
 USER spring:spring
 
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -4,6 +4,7 @@ services:
     container_name: eod-app
     volumes:
       - /eod/logs:/logs
+      - /eod/uploads:/eod/uploads
     restart: always
     ports:
       - "8000:8080"
@@ -26,6 +27,8 @@ services:
       - BSM_CLIENT_SECRET=${BSM_CLIENT_SECRET}
       - BSM_OAUTH_BASE_URL=${BSM_OAUTH_BASE_URL}
       - BSM_REDIRECT_URI=${BSM_REDIRECT_URI}
+      - FILE_UPLOAD_DIR=/eod/uploads
+      - FILE_UPLOAD_BASE_URL=${FILE_UPLOAD_BASE_URL}
     depends_on:
       mysql:
         condition: service_healthy

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -55,5 +55,5 @@ bsm.oauth.redirect-uri=${BSM_REDIRECT_URI:https://www.jojaemin.com/oauth/bsm}
 spring.servlet.multipart.enabled=true
 spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.max-request-size=10MB
-file.upload.dir=uploads
-file.upload.base-url=https://www.jojaemin.com
+file.upload.dir=${FILE_UPLOAD_DIR:./uploads}
+file.upload.base-url=${FILE_UPLOAD_BASE_URL:https://www.jojaemin.com}


### PR DESCRIPTION
## 요약
-  파일 업로드 경로를 환경변수로 설정 가능하게 변경
- Docker 컨테이너 내부에서 spring 유저에게 /eod/uploads 디렉토리 쓰기 권한 부여
- 볼륨 마운트 추가로 업로드 파일 영속성 보장
- AccessDeniedException: /eod/uploads 에러 해결




## 🔗 관련 이슈
close #

## 🔄 변경 사항
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 업데이트
- [ ] 스타일 변경
- [ ] 리팩토링
- [ ] 성능 개선
- [ ] 테스트 추가

### 변경된 내용
변경된 내용에 대한 자세한 설명을 작성해주세요.

### 변경 이유
왜 이러한 변경이 필요했는지 설명해주세요.

## ✅ 체크리스트
- [ ] 코드 리뷰 완료
- [ ] 테스트 통과
- [ ] 문서 업데이트 (필요한 경우)
- [ ] 브레이킹 체인지 확인