### PR TITLE
fix :: 이미지 업로드 디렉토리 권한 오류 수정

### DIFF
--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -160,6 +160,7 @@ jobs:
           echo "📁 로그 디렉토리 생성 중..."
           mkdir -p /eod/prod/logs
           mkdir -p /eod/uploads
+          chmod 777 /eod/uploads
           echo "✅ 디렉토리 생성 완료"
           echo "========================================="
 


### PR DESCRIPTION
## 📋 요약
- /eod/uploads 디렉토리 생성 후 chmod 777 추가
- 호스트 디렉토리가 Docker volume mount 시 spring 유저가 쓰기 권한을 잃는 문제 해결