### PR TITLE
feat(item): 물건별 소유권 주장 목록 조회 API 추가

### DIFF
--- a/src/main/java/com/eod/eod/domain/item/application/ItemClaimQueryService.java
+++ b/src/main/java/com/eod/eod/domain/item/application/ItemClaimQueryService.java
@@ -4,6 +4,7 @@ import com.eod.eod.domain.item.infrastructure.ItemClaimRepository;
 import com.eod.eod.domain.item.model.ItemClaim;
 import com.eod.eod.domain.item.presentation.dto.response.ClaimItemResponse;
 import com.eod.eod.domain.item.presentation.dto.response.ClaimItemListResponse;
+import com.eod.eod.domain.item.presentation.dto.response.ClaimRequestResponse;
 import com.eod.eod.domain.item.presentation.dto.response.ClaimRequestsResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -52,6 +53,13 @@ public class ItemClaimQueryService {
         }
 
         return ClaimRequestsResponse.from(claimPage, page);
+    }
+
+    public List<ClaimRequestResponse> getClaimsByItemId(Long itemId) {
+        return itemClaimRepository.findByItemIdAndItemDeletedAtIsNull(itemId)
+                .stream()
+                .map(ClaimRequestResponse::from)
+                .toList();
     }
 
     private ItemClaim.ClaimStatus parseStatus(String status) {

--- a/src/main/java/com/eod/eod/domain/item/infrastructure/ItemClaimRepository.java
+++ b/src/main/java/com/eod/eod/domain/item/infrastructure/ItemClaimRepository.java
@@ -23,4 +23,7 @@ public interface ItemClaimRepository extends JpaRepository<ItemClaim, Long>, Ite
 
     // 특정 물품에 대한 특정 상태의 소유권 주장 목록 조회
     List<ItemClaim> findByItemIdAndStatus(Long itemId, ItemClaim.ClaimStatus status);
+
+    // 특정 물품에 대한 전체 소유권 주장 목록 조회 (삭제된 물품 제외)
+    List<ItemClaim> findByItemIdAndItemDeletedAtIsNull(Long itemId);
 }

--- a/src/main/java/com/eod/eod/domain/item/presentation/ItemClaimController.java
+++ b/src/main/java/com/eod/eod/domain/item/presentation/ItemClaimController.java
@@ -7,6 +7,7 @@ import com.eod.eod.domain.item.model.ItemClaim;
 import com.eod.eod.domain.item.presentation.dto.request.ItemClaimRequest;
 import com.eod.eod.domain.item.presentation.dto.response.ClaimCountResponse;
 import com.eod.eod.domain.item.presentation.dto.response.ClaimItemListResponse;
+import com.eod.eod.domain.item.presentation.dto.response.ClaimRequestResponse;
 import com.eod.eod.domain.item.presentation.dto.response.ClaimRequestsResponse;
 import com.eod.eod.domain.item.presentation.dto.response.ItemClaimResponse;
 import com.eod.eod.domain.user.model.User;
@@ -23,6 +24,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 import org.springframework.validation.annotation.Validated;
 
 @RestController
@@ -198,6 +201,29 @@ public class ItemClaimController {
         }
 
         ClaimItemListResponse response = itemClaimQueryService.getPendingClaimItems();
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "물건별 소유권 주장 목록 조회", description = "특정 물건에 대해 소유권을 주장한 사람들의 목록을 조회합니다. ADMIN 권한이 필요합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "403", description = "ADMIN 권한 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = "{\"message\": \"ADMIN 권한이 필요합니다.\"}")
+                    ))
+    })
+    @GetMapping("/{itemId}/claims")
+    public ResponseEntity<List<ClaimRequestResponse>> getClaimsByItem(
+            @PathVariable Long itemId,
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal User currentUser
+    ) {
+        if (!currentUser.isAdmin()) {
+            throw new IllegalStateException("ADMIN 권한이 필요합니다.");
+        }
+
+        List<ClaimRequestResponse> response = itemClaimQueryService.getClaimsByItemId(itemId);
         return ResponseEntity.ok(response);
     }
 


### PR DESCRIPTION
## Summary
- `GET /items/{itemId}/claims` 엔드포인트 추가 (ADMIN 전용)
- 특정 물건에 대해 소유권을 주장한 사람들의 목록을 리스트 형태로 반환
- `ItemClaimRepository`에 `findByItemIdAndItemDeletedAtIsNull` 메서드 추가
- `ItemClaimQueryService`에 `getClaimsByItemId` 서비스 메서드 추가

## Test plan
- [ ] ADMIN 권한으로 `GET /items/{itemId}/claims` 호출 시 해당 물건의 소유권 주장 목록 반환 확인
- [ ] 소유권 주장이 없는 물건 조회 시 빈 리스트 반환 확인
- [ ] 비관리자 호출 시 예외 발생 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)