### PR TITLE
fix :: logout 401 오류 수정 - JWT 필터 shouldNotFilter 범위 조정

### DIFF
--- a/src/main/java/com/eod/eod/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/eod/eod/common/jwt/JwtAuthenticationFilter.java
@@ -121,6 +121,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         return path.startsWith("/oauth2/")
                 || path.startsWith("/login/")
                 || path.startsWith("/auth/oauth/")
-                || path.startsWith("/auth/"); // refresh, logout 등은 자체 로직에서 처리
+                || path.equals("/auth/refresh"); // refresh는 Refresh Token으로 자체 처리, logout은 JWT 인증 필요
     }
 }


### PR DESCRIPTION
## 요약
- /auth/ 전체를 JWT 필터 스킵 대상에서 제거
- /auth/logout은 JWT Access Token 인증이 필요하므로 필터를 통과하도록 수정
- /auth/refresh만 스킵 유지 (Refresh Token으로 자체 처리)

