### PR TITLE
fix: item detail disposalDate 응답 보강

### DIFF
--- a/src/main/java/com/eod/eod/domain/item/application/ItemQueryService.java
+++ b/src/main/java/com/eod/eod/domain/item/application/ItemQueryService.java
@@ -55,6 +55,7 @@ public class ItemQueryService {
                 .foundPlace(place.getPlace())
                 .foundPlaceDetail(item.getFoundPlaceDetail())
                 .category(item.getCategory())
+                .disposalDate(item.getDiscardedAt())
                 .build();
     }
 

--- a/src/main/java/com/eod/eod/domain/item/presentation/dto/response/ItemDetailResponse.java
+++ b/src/main/java/com/eod/eod/domain/item/presentation/dto/response/ItemDetailResponse.java
@@ -40,4 +40,7 @@ public class ItemDetailResponse {
 
     @Schema(description = "물품 카테고리", example = "전자기기")
     private Item.ItemCategory category;
+
+    @Schema(description = "폐기 예정일", example = "2026-01-01")
+    private String disposalDate;
 }


### PR DESCRIPTION
## Summary
- 물품 상세 응답 DTO에 `disposalDate`(폐기 예정일) 필드를 추가했습니다.
- `ItemQueryService` 매핑에 `item.getDiscardedAt()` 값을 `disposalDate`로 전달하도록 반영했습니다.
