### PR TITLE
fix: 지급 완료 물품 검색 제외 및 JWT 클레임 추가

### DIFF
--- a/src/main/java/com/eod/eod/common/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/eod/eod/common/jwt/JwtTokenProvider.java
@@ -1,5 +1,6 @@
 package com.eod.eod.common.jwt;
 
+import com.eod.eod.domain.user.model.User;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import lombok.RequiredArgsConstructor;
@@ -46,6 +47,33 @@ public class JwtTokenProvider {
                 .expiration(expiryDate)
                 .signWith(getSigningKey())
                 .compact();
+    }
+
+    // Access Token 생성
+    public String createAccessToken(User user) {
+        Date now = new Date();
+        long accessTokenTtlMillis = jwtProperties.getAccessTokenExpiration().toMillis();
+        Date expiryDate = new Date(now.getTime() + accessTokenTtlMillis);
+
+        JwtBuilder builder = Jwts.builder()
+                .subject(String.valueOf(user.getId()))
+                .claim("email", user.getEmail())
+                .claim("role", user.getRole().name())
+                .claim("type", "access")
+                .claim("name", user.getName())
+                .issuedAt(now)
+                .expiration(expiryDate);
+
+        addClaimIfPresent(builder, "studentCode", user.getStudentCode());
+
+        return builder.signWith(getSigningKey())
+                .compact();
+    }
+
+    private void addClaimIfPresent(JwtBuilder builder, String name, Object value) {
+        if (value != null) {
+            builder.claim(name, value);
+        }
     }
 
     // Refresh Token 생성

--- a/src/main/java/com/eod/eod/domain/auth/application/AuthService.java
+++ b/src/main/java/com/eod/eod/domain/auth/application/AuthService.java
@@ -35,7 +35,7 @@ public class AuthService {
         User user = storedToken.getUser();
 
         // 새로운 Access Token 및 Refresh Token 생성
-        String newAccessToken = tokenService.createAccessToken(user.getId(), user.getEmail(), user.getRole().name());
+        String newAccessToken = tokenService.createAccessToken(user);
         String newRefreshToken = tokenService.createRefreshToken(user.getId());
 
         // 기존 Refresh Token 삭제 후 새로운 Refresh Token 저장
@@ -55,7 +55,7 @@ public class AuthService {
 
     // OAuth2 로그인 성공 시 토큰 발급
     public TokenPair issueTokensForOAuth2Login(User user) {
-        String accessToken = tokenService.createAccessToken(user.getId(), user.getEmail(), user.getRole().name());
+        String accessToken = tokenService.createAccessToken(user);
         String refreshToken = tokenService.createRefreshToken(user.getId());
 
         // Refresh Token DB에 저장

--- a/src/main/java/com/eod/eod/domain/auth/application/TokenService.java
+++ b/src/main/java/com/eod/eod/domain/auth/application/TokenService.java
@@ -29,6 +29,11 @@ public class TokenService {
         return jwtTokenProvider.createAccessToken(userId, email, role);
     }
 
+    // Access Token 생성
+    public String createAccessToken(User user) {
+        return jwtTokenProvider.createAccessToken(user);
+    }
+
     // Refresh Token 생성
     public String createRefreshToken(Long userId) {
         return jwtTokenProvider.createRefreshToken(userId);

--- a/src/main/java/com/eod/eod/domain/item/infrastructure/ItemRepositoryImpl.java
+++ b/src/main/java/com/eod/eod/domain/item/infrastructure/ItemRepositoryImpl.java
@@ -34,6 +34,7 @@ public class ItemRepositoryImpl implements ItemRepositoryCustom {
         // 동적 쿼리 조건 생성
         BooleanBuilder builder = new BooleanBuilder();
         builder.and(item.deletedAt.isNull());
+        builder.and(item.status.ne(Item.ItemStatus.GIVEN));
 
         if (trimmedQuery != null && !trimmedQuery.isBlank()) {
             builder.and(item.name.containsIgnoreCase(trimmedQuery));

--- a/src/test/java/com/eod/eod/EodApplicationTests.java
+++ b/src/test/java/com/eod/eod/EodApplicationTests.java
@@ -2,8 +2,10 @@ package com.eod.eod;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class EodApplicationTests {
 
 	@Test

--- a/src/test/java/com/eod/eod/common/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/com/eod/eod/common/jwt/JwtTokenProviderTest.java
@@ -1,0 +1,65 @@
+package com.eod.eod.common.jwt;
+
+import com.eod.eod.domain.user.model.User;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JwtTokenProviderTest {
+
+    private static final String SECRET = "test-jwt-secret-key-for-testing-purposes-only-minimum-32-characters";
+
+    @Test
+    void accessToken에_사용자_이름과_studentCode를_담는다() {
+        JwtTokenProvider jwtTokenProvider = new JwtTokenProvider(jwtProperties());
+        User user = User.builder()
+                .grade(1)
+                .classNo(2)
+                .studentNo(3)
+                .oauthProvider("bsm")
+                .oauthId("123456")
+                .name("홍길동")
+                .email("hong@test.com")
+                .role(User.Role.USER)
+                .build();
+        ReflectionTestUtils.setField(user, "id", 1L);
+
+        String token = jwtTokenProvider.createAccessToken(user);
+
+        Claims claims = parseClaims(token);
+        assertThat(claims.getSubject()).isEqualTo("1");
+        assertThat(claims.get("email", String.class)).isEqualTo("hong@test.com");
+        assertThat(claims.get("role", String.class)).isEqualTo("USER");
+        assertThat(claims.get("type", String.class)).isEqualTo("access");
+        assertThat(claims.get("name", String.class)).isEqualTo("홍길동");
+        assertThat(claims.get("studentCode", Integer.class)).isEqualTo(1203);
+        assertThat(claims.get("grade")).isNull();
+        assertThat(claims.get("classNo")).isNull();
+        assertThat(claims.get("studentNo")).isNull();
+    }
+
+    private JwtProperties jwtProperties() {
+        JwtProperties jwtProperties = new JwtProperties();
+        jwtProperties.setSecret(SECRET);
+        jwtProperties.setAccessTokenExpiration(Duration.ofHours(1));
+        jwtProperties.setRefreshTokenExpiration(Duration.ofDays(7));
+        return jwtProperties;
+    }
+
+    private Claims parseClaims(String token) {
+        SecretKey key = Keys.hmacShaKeyFor(SECRET.getBytes(StandardCharsets.UTF_8));
+        return Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/src/test/java/com/eod/eod/domain/item/infrastructure/ItemRepositoryImplTest.java
+++ b/src/test/java/com/eod/eod/domain/item/infrastructure/ItemRepositoryImplTest.java
@@ -1,0 +1,90 @@
+package com.eod.eod.domain.item.infrastructure;
+
+import com.eod.eod.domain.item.model.Item;
+import com.eod.eod.domain.user.model.User;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class ItemRepositoryImplTest {
+
+    @Autowired
+    private ItemRepository itemRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Test
+    void searchItems는_상태_필터가_없어도_GIVEN_물품을_반환하지_않는다() {
+        Item givenItem = persistItem(Item.ItemStatus.GIVEN);
+
+        Page<Item> result = itemRepository.searchItems(
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "foundAt"))
+        );
+
+        assertThat(result.getContent()).doesNotContain(givenItem);
+        assertThat(result.getContent()).isEmpty();
+    }
+
+    @Test
+    void searchItems는_GIVEN_상태를_명시해도_GIVEN_물품을_반환하지_않는다() {
+        Item givenItem = persistItem(Item.ItemStatus.GIVEN);
+
+        Page<Item> result = itemRepository.searchItems(
+                null,
+                null,
+                List.of(Item.ItemStatus.GIVEN),
+                null,
+                null,
+                null,
+                PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "foundAt"))
+        );
+
+        assertThat(result.getContent()).doesNotContain(givenItem);
+        assertThat(result.getContent()).isEmpty();
+    }
+
+    private Item persistItem(Item.ItemStatus status) {
+        User admin = entityManager.persist(User.builder()
+                .oauthProvider("local")
+                .oauthId("admin-" + status.name())
+                .name("Admin")
+                .email("admin-" + status.name() + "@test.com")
+                .role(User.Role.ADMIN)
+                .build());
+
+        Item item = Item.builder()
+                .admin(admin)
+                .foundPlaceId(1L)
+                .foundPlaceDetail("상세 위치")
+                .name("테스트 물품")
+                .image("image.jpg")
+                .status(status)
+                .category(Item.ItemCategory.ETC)
+                .foundAt(LocalDateTime.now().minusDays(1))
+                .build();
+
+        Item persisted = entityManager.persist(item);
+        entityManager.flush();
+        entityManager.clear();
+        return persisted;
+    }
+}


### PR DESCRIPTION
## 요약
- 분실물 찾기 검색 결과에서 GIVEN 상태 물품이 노출되지 않도록 제외했습니다.
- 새로 발급되는 Access Token에 사용자 이름(name)과 학번(studentCode)을 담도록 변경했습니다.
- 검색 필터링과 JWT 클레임에 대한 회귀 테스트를 추가했습니다.

## 테스트
- ./gradlew test