### PR TITLE
feat: Discord 인증 연동

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,16 +3,16 @@
 GITHUB_REPOSITORY=bssmeod/eodiback
 
 # Database Connection
-SPRING_DATASOURCE_URL=jdbc:mysql://mysql:3306/eod
+SPRING_DATASOURCE_URL=jdbc:mysql://mysql:3306/eod?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul
 SPRING_DATASOURCE_USERNAME=eod_user
-SPRING_DATASOURCE_PASSWORD=your_secure_password
+SPRING_DATASOURCE_PASSWORD=eod_dev_password
 
 # Google OAuth2 Configuration
-GOOGLE_CLIENT_ID=your_google_client_id
-GOOGLE_CLIENT_SECRET=your_google_client_secret
+GOOGLE_CLIENT_ID=dev-google-client-id
+GOOGLE_CLIENT_SECRET=dev-google-client-secret
 
 # JWT Configuration (at least 32 characters)
-JWT_SECRET=your_jwt_secret
+JWT_SECRET=dev-jwt-secret-key-at-least-32-characters-long
 
 # External Server Configuration
 EXTERNAL_SERVER_BASE_URL=http://external-server:8080
@@ -22,11 +22,25 @@ EXTERNAL_SERVER_DEFAULT_UID=your_external_uid
 EXTERNAL_SERVER_DEFAULT_PASSWORD=your_external_password
 
 # Application URL Configuration
-BASE_URL=https://your-domain.com/eod
-FRONTEND_BASE_URL=https://your-frontend-domain.com
+BASE_URL=http://localhost:8000
+FRONTEND_BASE_URL=http://localhost:3000
+
+# Local Docker bind mounts for development
+HOST_LOGS_DIR=./.docker/logs
+HOST_UPLOADS_DIR=./.docker/uploads
+LOG_DIR=/logs
 
 # MySQL Configuration
-MYSQL_ROOT_PASSWORD=your_root_password
+MYSQL_ROOT_PASSWORD=eod_root_password
 MYSQL_DATABASE=eod
 MYSQL_USER=eod_user
-MYSQL_PASSWORD=your_secure_password
+MYSQL_PASSWORD=eod_dev_password
+
+# BSM OAuth
+BSM_CLIENT_ID=dev-bsm-client-id
+BSM_CLIENT_SECRET=dev-bsm-client-secret
+BSM_OAUTH_BASE_URL=https://auth.bssm.app
+BSM_REDIRECT_URI=http://localhost:8000/oauth/bsm
+
+# File upload
+FILE_UPLOAD_BASE_URL=http://localhost:8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,22 @@
-# Runtime stage with JRE (ARM64 compatible)
+FROM gradle:8.14.3-jdk17 AS builder
+WORKDIR /workspace
+
+COPY gradle gradle
+COPY gradlew settings.gradle build.gradle ./
+COPY src src
+
+RUN chmod +x gradlew && ./gradlew bootJar --no-daemon
+
 FROM eclipse-temurin:17-jre
 WORKDIR /eod
 
-# Copy the prebuilt jar from the workflow
-COPY build/libs/*.jar app.jar
+COPY --from=builder /workspace/build/libs/*.jar app.jar
 
-# Create upload directory with proper permissions
-RUN mkdir -p /eod/uploads && \
+RUN mkdir -p /eod/uploads /logs && \
     groupadd -r spring && \
     useradd -r -g spring spring && \
-    chown -R spring:spring /eod
+    chown -R spring:spring /eod /logs
 
-# Run as non-root user (Debian-based)
 USER spring:spring
 
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,29 +1,32 @@
 services:
   app:
-    image: ghcr.io/${GITHUB_REPOSITORY:-bssmeod/eodiback}:latest
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: eodi-app-dev:local
     container_name: eod-app-dev
     volumes:
-      - /eod/logs:/logs
-      - /eod/uploads:/eod/uploads
+      - ${HOST_LOGS_DIR:-./.docker/logs}:/logs
+      - ${HOST_UPLOADS_DIR:-./.docker/uploads}:/eod/uploads
     restart: always
     ports:
       - "8000:8080"
     environment:
-      - SPRING_DATASOURCE_URL=${SPRING_DATASOURCE_URL}
-      - SPRING_DATASOURCE_USERNAME=${SPRING_DATASOURCE_USERNAME}
-      - SPRING_DATASOURCE_PASSWORD=${SPRING_DATASOURCE_PASSWORD}
-      - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}
-      - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET}
-      - JWT_SECRET=${JWT_SECRET}
-      - BASE_URL=${BASE_URL}
-      - FRONTEND_BASE_URL=${FRONTEND_BASE_URL}
-      - LOG_DIR=${LOG_DIR}
-      - BSM_CLIENT_ID=${BSM_CLIENT_ID}
-      - BSM_CLIENT_SECRET=${BSM_CLIENT_SECRET}
-      - BSM_OAUTH_BASE_URL=${BSM_OAUTH_BASE_URL}
-      - BSM_REDIRECT_URI=${BSM_REDIRECT_URI}
+      - SPRING_DATASOURCE_URL=${SPRING_DATASOURCE_URL:-jdbc:mysql://mysql:3306/eod?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul}
+      - SPRING_DATASOURCE_USERNAME=${SPRING_DATASOURCE_USERNAME:-eod_user}
+      - SPRING_DATASOURCE_PASSWORD=${SPRING_DATASOURCE_PASSWORD:-eod_dev_password}
+      - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID:-dev-google-client-id}
+      - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET:-dev-google-client-secret}
+      - JWT_SECRET=${JWT_SECRET:-dev-jwt-secret-key-at-least-32-characters-long}
+      - BASE_URL=${BASE_URL:-http://localhost:8000}
+      - FRONTEND_BASE_URL=${FRONTEND_BASE_URL:-http://localhost:3000}
+      - LOG_DIR=${LOG_DIR:-/logs}
+      - BSM_CLIENT_ID=${BSM_CLIENT_ID:-dev-bsm-client-id}
+      - BSM_CLIENT_SECRET=${BSM_CLIENT_SECRET:-dev-bsm-client-secret}
+      - BSM_OAUTH_BASE_URL=${BSM_OAUTH_BASE_URL:-https://auth.bssm.app}
+      - BSM_REDIRECT_URI=${BSM_REDIRECT_URI:-http://localhost:8000/oauth/bsm}
       - FILE_UPLOAD_DIR=/eod/uploads
-      - FILE_UPLOAD_BASE_URL=${FILE_UPLOAD_BASE_URL}
+      - FILE_UPLOAD_BASE_URL=${FILE_UPLOAD_BASE_URL:-http://localhost:8000}
     depends_on:
       mysql:
         condition: service_healthy
@@ -35,10 +38,10 @@ services:
     container_name: eod-mysql-dev
     restart: always
     environment:
-      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
-      MYSQL_DATABASE: ${MYSQL_DATABASE}
-      MYSQL_USER: ${MYSQL_USER}
-      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-eod_root_password}
+      MYSQL_DATABASE: ${MYSQL_DATABASE:-eod}
+      MYSQL_USER: ${MYSQL_USER:-eod_user}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD:-eod_dev_password}
     ports:
       - "3306:3306"
     volumes:
@@ -84,8 +87,7 @@ services:
 
 volumes:
   mysql-data-dev:
-    external: true
-    name: eod_mysql-data-dev
+    name: eodi_mysql-data-dev
 
 networks:
   eod-network-dev:

--- a/src/main/java/com/eod/eod/common/config/SecurityConfig.java
+++ b/src/main/java/com/eod/eod/common/config/SecurityConfig.java
@@ -88,6 +88,8 @@ public class SecurityConfig {
                         .requestMatchers("/auth/**").permitAll()
                         // 테스트 페이지 허용
                         .requestMatchers("/test/**").permitAll()
+                        // Discord 내부 인증 API 허용
+                        .requestMatchers(HttpMethod.POST, "/discord/verify").permitAll()
 
                         // ===== Items API 세분화 =====
                         // 공개 물품 조회 API 허용

--- a/src/main/java/com/eod/eod/common/config/SecurityConfig.java
+++ b/src/main/java/com/eod/eod/common/config/SecurityConfig.java
@@ -88,8 +88,8 @@ public class SecurityConfig {
                         .requestMatchers("/auth/**").permitAll()
                         // 테스트 페이지 허용
                         .requestMatchers("/test/**").permitAll()
-                        // Discord 내부 인증 API 허용
-                        .requestMatchers(HttpMethod.POST, "/discord/verify").permitAll()
+                        // Discord 봇 API 허용 (봇은 JWT 인증 없이 호출)
+                        .requestMatchers("/discord/**").permitAll()
 
                         // ===== Items API 세분화 =====
                         // 공개 물품 조회 API 허용

--- a/src/main/java/com/eod/eod/domain/auth/application/BsmLoginService.java
+++ b/src/main/java/com/eod/eod/domain/auth/application/BsmLoginService.java
@@ -34,6 +34,24 @@ public class BsmLoginService {
         return new LoginResult(tokenPair.getAccessToken(), tokenPair.getRefreshToken(), user);
     }
 
+    public User linkDiscordId(User user, String discordId) {
+        if (discordId == null || discordId.isBlank()) {
+            return user;
+        }
+        if (discordId.equals(user.getDiscordId())) {
+            return user;
+        }
+
+        userRepository.findByDiscordId(discordId)
+                .filter(existingUser -> !existingUser.getId().equals(user.getId()))
+                .ifPresent(existingUser -> {
+                    throw new IllegalStateException("이미 다른 계정에 연결된 Discord ID입니다.");
+                });
+
+        user.linkDiscordId(discordId);
+        return userRepository.save(user);
+    }
+
     private User findOrCreateUser(BsmUserInfo userInfo) {
         Optional<User> byProviderAndId = userRepository.findByOauthProviderAndOauthId(PROVIDER, userInfo.oauthId());
         if (byProviderAndId.isPresent()) {

--- a/src/main/java/com/eod/eod/domain/auth/application/DiscordOAuthStateService.java
+++ b/src/main/java/com/eod/eod/domain/auth/application/DiscordOAuthStateService.java
@@ -1,0 +1,51 @@
+package com.eod.eod.domain.auth.application;
+
+import com.eod.eod.domain.auth.infrastructure.DiscordOAuthStateRepository;
+import com.eod.eod.domain.auth.model.DiscordOAuthState;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class DiscordOAuthStateService {
+
+    private static final long STATE_TTL_MINUTES = 10L;
+
+    private final DiscordOAuthStateRepository discordOAuthStateRepository;
+
+    @Transactional
+    public void save(String state, String discordId) {
+        LocalDateTime now = LocalDateTime.now();
+        discordOAuthStateRepository.deleteByExpiresAtBefore(now);
+        discordOAuthStateRepository.save(new DiscordOAuthState(state, discordId, now.plusMinutes(STATE_TTL_MINUTES)));
+    }
+
+    @Transactional
+    public Optional<String> consumeDiscordId(String state) {
+        if (state == null || state.isBlank()) {
+            return Optional.empty();
+        }
+
+        Optional<DiscordOAuthState> savedState = discordOAuthStateRepository.findById(state);
+        if (savedState.isEmpty()) {
+            return Optional.empty();
+        }
+
+        DiscordOAuthState discordOAuthState = savedState.get();
+        discordOAuthStateRepository.delete(discordOAuthState);
+
+        if (discordOAuthState.isExpired(LocalDateTime.now())) {
+            log.warn("Discord OAuth state 만료됨 (discordId={}). Discord 연결 없이 로그인 진행됩니다.",
+                    discordOAuthState.getDiscordId());
+            return Optional.empty();
+        }
+
+        return Optional.of(discordOAuthState.getDiscordId());
+    }
+}

--- a/src/main/java/com/eod/eod/domain/auth/infrastructure/DiscordOAuthStateRepository.java
+++ b/src/main/java/com/eod/eod/domain/auth/infrastructure/DiscordOAuthStateRepository.java
@@ -1,0 +1,11 @@
+package com.eod.eod.domain.auth.infrastructure;
+
+import com.eod.eod.domain.auth.model.DiscordOAuthState;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+
+public interface DiscordOAuthStateRepository extends JpaRepository<DiscordOAuthState, String> {
+
+    void deleteByExpiresAtBefore(LocalDateTime threshold);
+}

--- a/src/main/java/com/eod/eod/domain/auth/model/DiscordOAuthState.java
+++ b/src/main/java/com/eod/eod/domain/auth/model/DiscordOAuthState.java
@@ -1,0 +1,42 @@
+package com.eod.eod.domain.auth.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "discord_oauth_states")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DiscordOAuthState {
+
+    @Id
+    @Column(name = "state", nullable = false, length = 100)
+    private String state;
+
+    @Column(name = "discord_id", nullable = false, length = 20)
+    private String discordId;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    public DiscordOAuthState(String state, String discordId, LocalDateTime expiresAt) {
+        this.state = state;
+        this.discordId = discordId;
+        this.expiresAt = expiresAt;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public boolean isExpired(LocalDateTime now) {
+        return expiresAt.isBefore(now);
+    }
+}

--- a/src/main/java/com/eod/eod/domain/auth/presentation/BsmOAuthCallbackController.java
+++ b/src/main/java/com/eod/eod/domain/auth/presentation/BsmOAuthCallbackController.java
@@ -2,6 +2,7 @@ package com.eod.eod.domain.auth.presentation;
 
 import com.eod.eod.common.util.CookieUtil;
 import com.eod.eod.domain.auth.application.BsmLoginService;
+import com.eod.eod.domain.auth.application.DiscordOAuthStateService;
 import com.eod.eod.domain.auth.application.TokenService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -29,6 +30,7 @@ public class BsmOAuthCallbackController {
     private static final String STATE_COOKIE_NAME = "bsm_oauth_state";
 
     private final BsmLoginService bsmLoginService;
+    private final DiscordOAuthStateService discordOAuthStateService;
     private final TokenService tokenService;
     private final CookieUtil cookieUtil;
 
@@ -51,12 +53,13 @@ public class BsmOAuthCallbackController {
             HttpServletResponse response
     ) throws IOException {
         try {
+            String discordId = discordOAuthStateService.consumeDiscordId(state).orElse(null);
             String expectedState = cookieUtil.getCookie(request, STATE_COOKIE_NAME)
                     .map(c -> c.getValue())
                     .orElse(null);
 
-            // State 검증 (BSM OAuth가 state를 반환하지 않으므로 경고만 처리)
-            if (expectedState == null || state == null || !expectedState.equals(state)) {
+            // Discord 봇 플로우가 아니면 기존 쿠키 기반 state를 유지한다.
+            if (discordId == null && (expectedState == null || state == null || !expectedState.equals(state))) {
                 log.warn("BSM OAuth state mismatch. expected={}, actual={} (continuing login process)", expectedState, state);
             }
 
@@ -67,6 +70,16 @@ public class BsmOAuthCallbackController {
 
             BsmLoginService.LoginResult loginResult = bsmLoginService.login(code);
 
+            String discordLinkError = null;
+            if (discordId != null) {
+                try {
+                    bsmLoginService.linkDiscordId(loginResult.user(), discordId);
+                } catch (IllegalStateException e) {
+                    log.warn("Discord ID 연결 실패 (BSM 로그인은 성공): {}", e.getMessage());
+                    discordLinkError = e.getMessage();
+                }
+            }
+
             cookieUtil.addTokenCookie(
                     response,
                     "refreshToken",
@@ -76,12 +89,19 @@ public class BsmOAuthCallbackController {
             );
 
             // Google OAuth2와 동일하게 access token을 fragment로 전달
-            String redirectUrl = String.format(
-                    "%s%s#token=%s&provider=bsm",
-                    frontendBaseUrl,
-                    frontendCallbackPath,
-                    loginResult.accessToken()
-            );
+            // Discord 연결 실패 시에도 BSM 로그인은 유지하고 에러 정보를 함께 전달
+            String redirectUrl = discordLinkError != null
+                    ? String.format(
+                            "%s%s#token=%s&provider=bsm&discord_error=%s",
+                            frontendBaseUrl,
+                            frontendCallbackPath,
+                            loginResult.accessToken(),
+                            URLEncoder.encode(discordLinkError, StandardCharsets.UTF_8))
+                    : String.format(
+                            "%s%s#token=%s&provider=bsm",
+                            frontendBaseUrl,
+                            frontendCallbackPath,
+                            loginResult.accessToken());
             response.sendRedirect(redirectUrl);
         } catch (Exception e) {
             log.error("BSM OAuth callback failed", e);

--- a/src/main/java/com/eod/eod/domain/auth/presentation/BsmOAuthController.java
+++ b/src/main/java/com/eod/eod/domain/auth/presentation/BsmOAuthController.java
@@ -2,13 +2,17 @@ package com.eod.eod.domain.auth.presentation;
 
 import com.eod.eod.common.util.CookieUtil;
 import com.eod.eod.domain.auth.application.BsmOAuthService;
+import com.eod.eod.domain.auth.application.DiscordOAuthStateService;
+import com.eod.eod.domain.auth.presentation.dto.response.BsmAuthorizeUrlResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,6 +26,7 @@ import java.util.Base64;
 public class BsmOAuthController {
 
     private final BsmOAuthService bsmOAuthService;
+    private final DiscordOAuthStateService discordOAuthStateService;
     private final CookieUtil cookieUtil;
 
     private static final String STATE_COOKIE_NAME = "bsm_oauth_state";
@@ -40,6 +45,18 @@ public class BsmOAuthController {
         String authorizeUrl = bsmOAuthService.buildAuthorizeUrl(state);
         response.setStatus(302);
         response.setHeader("Location", authorizeUrl);
+    }
+
+    @GetMapping("/authorize/discord")
+    @Operation(summary = "Discord 봇용 BSM 로그인 URL 발급", description = "쿠키 없이 사용할 수 있도록 state와 Discord ID를 서버에 저장하고 OAuth URL을 JSON으로 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "OAuth URL 반환")
+    })
+    public ResponseEntity<BsmAuthorizeUrlResponse> authorizeForDiscord(@RequestParam("discordId") String discordId) {
+        String state = generateState();
+        discordOAuthStateService.save(state, discordId);
+        String authorizeUrl = bsmOAuthService.buildAuthorizeUrl(state);
+        return ResponseEntity.ok(new BsmAuthorizeUrlResponse(authorizeUrl));
     }
 
     private String generateState() {

--- a/src/main/java/com/eod/eod/domain/auth/presentation/dto/response/BsmAuthorizeUrlResponse.java
+++ b/src/main/java/com/eod/eod/domain/auth/presentation/dto/response/BsmAuthorizeUrlResponse.java
@@ -1,0 +1,4 @@
+package com.eod.eod.domain.auth.presentation.dto.response;
+
+public record BsmAuthorizeUrlResponse(String url) {
+}

--- a/src/main/java/com/eod/eod/domain/discord/application/DiscordVerifyService.java
+++ b/src/main/java/com/eod/eod/domain/discord/application/DiscordVerifyService.java
@@ -1,0 +1,134 @@
+package com.eod.eod.domain.discord.application;
+
+import com.eod.eod.domain.discord.exception.DiscordVerifyException;
+import com.eod.eod.domain.discord.presentation.dto.request.DiscordVerifyRequest;
+import com.eod.eod.domain.discord.presentation.dto.response.DiscordVerifyResponse;
+import com.eod.eod.domain.user.infrastructure.UserRepository;
+import com.eod.eod.domain.user.model.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Service
+@RequiredArgsConstructor
+public class DiscordVerifyService {
+
+    private static final Pattern NICKNAME_PATTERN = Pattern.compile("^(\\d+)기_([^_]+)$");
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public DiscordVerifyResponse verify(DiscordVerifyRequest request) {
+        ParsedNickname parsedNickname = parseNickname(request.nickname());
+        List<User> students = userRepository.findByName(parsedNickname.name());
+        students = filterStudentsByCohort(students, parsedNickname.expectedGrade());
+
+        if (students.isEmpty()) {
+            throw DiscordVerifyException.studentNotFound();
+        }
+
+        User student = resolveStudent(students, request.studentId());
+        return connectDiscordAccount(student, request.discordUserId());
+    }
+
+    private ParsedNickname parseNickname(String nickname) {
+        Matcher matcher = NICKNAME_PATTERN.matcher(nickname.trim());
+        if (!matcher.matches()) {
+            throw DiscordVerifyException.invalidNicknameFormat();
+        }
+
+        Integer cohort = Integer.parseInt(matcher.group(1));
+        Integer expectedGrade = mapCohortToGrade(cohort);
+        return new ParsedNickname(matcher.group(2).trim(), expectedGrade);
+    }
+
+    private List<User> filterStudentsByCohort(List<User> students, Integer expectedGrade) {
+        if (expectedGrade == null) {
+            return students;
+        }
+
+        return students.stream()
+                .filter(student -> Objects.equals(student.getGrade(), expectedGrade))
+                .collect(Collectors.toList());
+    }
+
+    private Integer mapCohortToGrade(int cohort) {
+        return switch (cohort) {
+            case 4 -> 3;
+            case 5 -> 2;
+            case 6 -> 1;
+            default -> null;
+        };
+    }
+
+    private User resolveStudent(List<User> students, String requestStudentId) {
+        if (students.size() == 1) {
+            User student = students.get(0);
+            if (hasText(requestStudentId)) {
+                validateStudentId(student, requestStudentId);
+            }
+            return student;
+        }
+
+        if (!hasText(requestStudentId)) {
+            throw DiscordVerifyException.duplicateStudent();
+        }
+
+        for (User student : students) {
+            Integer studentCode = student.getStudentCode();
+            if (studentCode == null) {
+                continue;
+            }
+
+            String actualStudentId = String.format("%04d", studentCode);
+            if (Objects.equals(actualStudentId, requestStudentId)) {
+                return student;
+            }
+        }
+
+        throw DiscordVerifyException.studentIdMismatch();
+    }
+
+    private void validateStudentId(User student, String requestStudentId) {
+        Integer studentCode = student.getStudentCode();
+        if (studentCode == null) {
+            throw DiscordVerifyException.studentIdMismatch();
+        }
+
+        String actualStudentId = String.format("%04d", studentCode);
+        if (!actualStudentId.equals(requestStudentId)) {
+            throw DiscordVerifyException.studentIdMismatch();
+        }
+    }
+
+    private DiscordVerifyResponse connectDiscordAccount(User student, String discordUserId) {
+        if (hasText(student.getDiscordId())) {
+            if (Objects.equals(student.getDiscordId(), discordUserId)) {
+                return DiscordVerifyResponse.alreadyVerified("이미 인증된 계정입니다.");
+            }
+            throw DiscordVerifyException.discordAlreadyLinked();
+        }
+
+        userRepository.findByDiscordId(discordUserId)
+                .filter(existingUser -> !Objects.equals(existingUser.getId(), student.getId()))
+                .ifPresent(existingUser -> {
+                    throw DiscordVerifyException.discordUserAlreadyAssigned();
+                });
+
+        student.updateDiscordId(discordUserId);
+        return DiscordVerifyResponse.success("인증이 완료되었습니다.");
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+
+    private record ParsedNickname(String name, Integer expectedGrade) {
+    }
+}

--- a/src/main/java/com/eod/eod/domain/discord/application/PickupDateService.java
+++ b/src/main/java/com/eod/eod/domain/discord/application/PickupDateService.java
@@ -1,0 +1,58 @@
+package com.eod.eod.domain.discord.application;
+
+import com.eod.eod.domain.user.infrastructure.UserRepository;
+import com.eod.eod.domain.user.model.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.MonthDay;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+@Service
+@RequiredArgsConstructor
+public class PickupDateService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void savePickupDate(String discordId, String pickupDateStr) {
+        LocalDateTime pickupDate = parsePickupDate(pickupDateStr);
+
+        if (!pickupDate.isAfter(LocalDateTime.now())) {
+            throw new IllegalArgumentException("픽업 날짜는 현재 시각 이후여야 합니다.");
+        }
+
+        User user = userRepository.findByDiscordId(discordId)
+                .orElseThrow(() -> new IllegalArgumentException("학생을 찾을 수 없습니다."));
+
+        user.updatePickupDate(pickupDate);
+    }
+
+    private LocalDateTime parsePickupDate(String input) {
+        try {
+            int lastSlash = input.lastIndexOf("/");
+            if (lastSlash < 1) {
+                throw new IllegalArgumentException("날짜 형식이 올바르지 않습니다. (예: 4/23/12:00)");
+            }
+            String datePart = input.substring(0, lastSlash);
+            String timePart = input.substring(lastSlash + 1);
+
+            MonthDay monthDay = MonthDay.parse(datePart, DateTimeFormatter.ofPattern("M/d"));
+            LocalTime time = LocalTime.parse(timePart, DateTimeFormatter.ofPattern("HH:mm"));
+
+            return LocalDateTime.of(
+                    LocalDate.now()
+                            .withMonth(monthDay.getMonthValue())
+                            .withDayOfMonth(monthDay.getDayOfMonth()),
+                    time
+            );
+        } catch (DateTimeParseException e) {
+            throw new IllegalArgumentException("날짜 형식이 올바르지 않습니다. (예: 4/23/12:00)");
+        }
+    }
+}

--- a/src/main/java/com/eod/eod/domain/discord/exception/DiscordVerifyException.java
+++ b/src/main/java/com/eod/eod/domain/discord/exception/DiscordVerifyException.java
@@ -1,0 +1,81 @@
+package com.eod.eod.domain.discord.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class DiscordVerifyException extends RuntimeException {
+
+    private final HttpStatus httpStatus;
+    private final String status;
+    private final String code;
+    private final boolean requiresStudentId;
+
+    private DiscordVerifyException(HttpStatus httpStatus, String status, String code, boolean requiresStudentId, String message) {
+        super(message);
+        this.httpStatus = httpStatus;
+        this.status = status;
+        this.code = code;
+        this.requiresStudentId = requiresStudentId;
+    }
+
+    public static DiscordVerifyException invalidNicknameFormat() {
+        return new DiscordVerifyException(
+                HttpStatus.BAD_REQUEST,
+                "invalid_request",
+                "INVALID_NICKNAME_FORMAT",
+                false,
+                "닉네임 형식이 올바르지 않습니다. `4기_김현호` 형식으로 입력해주세요."
+        );
+    }
+
+    public static DiscordVerifyException duplicateStudent() {
+        return new DiscordVerifyException(
+                HttpStatus.CONFLICT,
+                "duplicate",
+                "DUPLICATE_STUDENT",
+                true,
+                "동명이인이 있어 학번 입력이 필요합니다."
+        );
+    }
+
+    public static DiscordVerifyException studentNotFound() {
+        return new DiscordVerifyException(
+                HttpStatus.NOT_FOUND,
+                "not_found",
+                "STUDENT_NOT_FOUND",
+                false,
+                "일치하는 학생 정보를 찾을 수 없습니다."
+        );
+    }
+
+    public static DiscordVerifyException studentIdMismatch() {
+        return new DiscordVerifyException(
+                HttpStatus.BAD_REQUEST,
+                "mismatch",
+                "STUDENT_ID_MISMATCH",
+                false,
+                "입력한 학번과 닉네임 정보가 일치하지 않습니다."
+        );
+    }
+
+    public static DiscordVerifyException discordAlreadyLinked() {
+        return new DiscordVerifyException(
+                HttpStatus.CONFLICT,
+                "already_linked",
+                "DISCORD_ALREADY_LINKED",
+                false,
+                "이미 다른 디스코드 계정에 연결된 학생입니다."
+        );
+    }
+
+    public static DiscordVerifyException discordUserAlreadyAssigned() {
+        return new DiscordVerifyException(
+                HttpStatus.CONFLICT,
+                "already_linked",
+                "DISCORD_ALREADY_LINKED",
+                false,
+                "이미 다른 학생에 연결된 디스코드 계정입니다."
+        );
+    }
+}

--- a/src/main/java/com/eod/eod/domain/discord/presentation/DiscordController.java
+++ b/src/main/java/com/eod/eod/domain/discord/presentation/DiscordController.java
@@ -1,0 +1,26 @@
+package com.eod.eod.domain.discord.presentation;
+
+import com.eod.eod.domain.discord.application.DiscordVerifyService;
+import com.eod.eod.domain.discord.presentation.dto.request.DiscordVerifyRequest;
+import com.eod.eod.domain.discord.presentation.dto.response.DiscordVerifyResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/discord")
+public class DiscordController {
+
+    private final DiscordVerifyService discordVerifyService;
+
+    @PostMapping("/verify")
+    public ResponseEntity<DiscordVerifyResponse> verify(@Valid @RequestBody DiscordVerifyRequest request) {
+        DiscordVerifyResponse response = discordVerifyService.verify(request);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/eod/eod/domain/discord/presentation/DiscordController.java
+++ b/src/main/java/com/eod/eod/domain/discord/presentation/DiscordController.java
@@ -1,6 +1,9 @@
 package com.eod.eod.domain.discord.presentation;
 
 import com.eod.eod.domain.discord.application.DiscordVerifyService;
+import com.eod.eod.domain.discord.application.PickupDateService;
+import com.eod.eod.domain.discord.presentation.dto.PickupDateRequest;
+import com.eod.eod.domain.discord.presentation.dto.PickupDateResponse;
 import com.eod.eod.domain.discord.presentation.dto.request.DiscordVerifyRequest;
 import com.eod.eod.domain.discord.presentation.dto.response.DiscordVerifyResponse;
 import jakarta.validation.Valid;
@@ -12,15 +15,22 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequiredArgsConstructor
 @RequestMapping("/discord")
+@RequiredArgsConstructor
 public class DiscordController {
 
     private final DiscordVerifyService discordVerifyService;
+    private final PickupDateService pickupDateService;
 
     @PostMapping("/verify")
     public ResponseEntity<DiscordVerifyResponse> verify(@Valid @RequestBody DiscordVerifyRequest request) {
         DiscordVerifyResponse response = discordVerifyService.verify(request);
         return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/pickup-date")
+    public ResponseEntity<PickupDateResponse> savePickupDate(@Valid @RequestBody PickupDateRequest request) {
+        pickupDateService.savePickupDate(request.discordId(), request.pickupDate());
+        return ResponseEntity.ok(new PickupDateResponse(true, "날짜가 등록되었습니다."));
     }
 }

--- a/src/main/java/com/eod/eod/domain/discord/presentation/DiscordExceptionHandler.java
+++ b/src/main/java/com/eod/eod/domain/discord/presentation/DiscordExceptionHandler.java
@@ -1,0 +1,66 @@
+package com.eod.eod.domain.discord.presentation;
+
+import com.eod.eod.domain.discord.exception.DiscordVerifyException;
+import com.eod.eod.domain.discord.presentation.dto.response.DiscordVerifyResponse;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@RestControllerAdvice(assignableTypes = DiscordController.class)
+public class DiscordExceptionHandler {
+
+    @ExceptionHandler(DiscordVerifyException.class)
+    public ResponseEntity<DiscordVerifyResponse> handleDiscordVerifyException(DiscordVerifyException exception) {
+        return ResponseEntity.status(exception.getHttpStatus())
+                .body(DiscordVerifyResponse.fail(
+                        exception.getStatus(),
+                        exception.getCode(),
+                        exception.isRequiresStudentId(),
+                        exception.getMessage()
+                ));
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<DiscordVerifyResponse> handleIllegalArgumentException(IllegalArgumentException exception) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(DiscordVerifyResponse.fail("invalid_request", "INVALID_REQUEST", false, exception.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<DiscordVerifyResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException exception) {
+        String message = exception.getBindingResult().getAllErrors().stream()
+                .map(error -> ((FieldError) error).getDefaultMessage())
+                .findFirst()
+                .orElse("잘못된 요청입니다.");
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(DiscordVerifyResponse.fail("invalid_request", "INVALID_REQUEST", false, message));
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<DiscordVerifyResponse> handleConstraintViolationException(ConstraintViolationException exception) {
+        String message = exception.getConstraintViolations().stream()
+                .map(violation -> violation.getMessage())
+                .findFirst()
+                .orElse("잘못된 요청입니다.");
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(DiscordVerifyResponse.fail("invalid_request", "INVALID_REQUEST", false, message));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<DiscordVerifyResponse> handleException(Exception exception) {
+        log.error("Unhandled discord verify exception", exception);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(DiscordVerifyResponse.internalServerError());
+    }
+}

--- a/src/main/java/com/eod/eod/domain/discord/presentation/dto/PickupDateRequest.java
+++ b/src/main/java/com/eod/eod/domain/discord/presentation/dto/PickupDateRequest.java
@@ -1,0 +1,10 @@
+package com.eod.eod.domain.discord.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PickupDateRequest(
+        @NotBlank(message = "discordId는 필수입니다.")
+        String discordId,
+        @NotBlank(message = "pickupDate는 필수입니다.")
+        String pickupDate
+) {}

--- a/src/main/java/com/eod/eod/domain/discord/presentation/dto/PickupDateResponse.java
+++ b/src/main/java/com/eod/eod/domain/discord/presentation/dto/PickupDateResponse.java
@@ -1,0 +1,6 @@
+package com.eod.eod.domain.discord.presentation.dto;
+
+public record PickupDateResponse(
+        boolean success,
+        String message
+) {}

--- a/src/main/java/com/eod/eod/domain/discord/presentation/dto/request/DiscordVerifyRequest.java
+++ b/src/main/java/com/eod/eod/domain/discord/presentation/dto/request/DiscordVerifyRequest.java
@@ -1,0 +1,14 @@
+package com.eod.eod.domain.discord.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record DiscordVerifyRequest(
+        String studentId,
+
+        @NotBlank(message = "nickname은 필수입니다.")
+        String nickname,
+
+        @NotBlank(message = "discordUserId는 필수입니다.")
+        String discordUserId
+) {
+}

--- a/src/main/java/com/eod/eod/domain/discord/presentation/dto/response/DiscordVerifyResponse.java
+++ b/src/main/java/com/eod/eod/domain/discord/presentation/dto/response/DiscordVerifyResponse.java
@@ -1,0 +1,25 @@
+package com.eod.eod.domain.discord.presentation.dto.response;
+
+public record DiscordVerifyResponse(
+        boolean success,
+        String status,
+        String code,
+        Boolean requiresStudentId,
+        String message
+) {
+    public static DiscordVerifyResponse success(String message) {
+        return new DiscordVerifyResponse(true, "verified", null, false, message);
+    }
+
+    public static DiscordVerifyResponse alreadyVerified(String message) {
+        return new DiscordVerifyResponse(true, "already_verified", null, false, message);
+    }
+
+    public static DiscordVerifyResponse fail(String status, String code, boolean requiresStudentId, String message) {
+        return new DiscordVerifyResponse(false, status, code, requiresStudentId, message);
+    }
+
+    public static DiscordVerifyResponse internalServerError() {
+        return new DiscordVerifyResponse(false, "error", "INTERNAL_SERVER_ERROR", false, "서버 오류가 발생했습니다.");
+    }
+}

--- a/src/main/java/com/eod/eod/domain/user/infrastructure/UserRepository.java
+++ b/src/main/java/com/eod/eod/domain/user/infrastructure/UserRepository.java
@@ -3,6 +3,7 @@ package com.eod.eod.domain.user.infrastructure;
 import com.eod.eod.domain.user.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -13,4 +14,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByGradeAndClassNoAndStudentNo(Integer grade, Integer classNo, Integer studentNo);
 
     Optional<User> findByGradeAndClassNoAndStudentNoAndName(Integer grade, Integer classNo, Integer studentNo, String name);
+
+    List<User> findByName(String name);
+
+    Optional<User> findByDiscordId(String discordId);
 }

--- a/src/main/java/com/eod/eod/domain/user/infrastructure/UserRepository.java
+++ b/src/main/java/com/eod/eod/domain/user/infrastructure/UserRepository.java
@@ -11,11 +11,11 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByOauthProviderAndOauthId(String provider, String providerId);
 
+    Optional<User> findByDiscordId(String discordId);
+
     Optional<User> findByGradeAndClassNoAndStudentNo(Integer grade, Integer classNo, Integer studentNo);
 
     Optional<User> findByGradeAndClassNoAndStudentNoAndName(Integer grade, Integer classNo, Integer studentNo, String name);
 
     List<User> findByName(String name);
-
-    Optional<User> findByDiscordId(String discordId);
 }

--- a/src/main/java/com/eod/eod/domain/user/infrastructure/UserRepository.java
+++ b/src/main/java/com/eod/eod/domain/user/infrastructure/UserRepository.java
@@ -11,11 +11,11 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByOauthProviderAndOauthId(String provider, String providerId);
 
-    Optional<User> findByDiscordId(String discordId);
-
     Optional<User> findByGradeAndClassNoAndStudentNo(Integer grade, Integer classNo, Integer studentNo);
 
     Optional<User> findByGradeAndClassNoAndStudentNoAndName(Integer grade, Integer classNo, Integer studentNo, String name);
 
     List<User> findByName(String name);
+
+    Optional<User> findByDiscordId(String discordId);
 }

--- a/src/main/java/com/eod/eod/domain/user/model/User.java
+++ b/src/main/java/com/eod/eod/domain/user/model/User.java
@@ -117,6 +117,10 @@ public class User {
         this.studentNo = studentNo;
     }
 
+    public void updateDiscordId(String discordId) {
+        this.discordId = discordId;
+    }
+
     public Integer getStudentCode() {
         if (grade == null || classNo == null || studentNo == null) {
             return null;

--- a/src/main/java/com/eod/eod/domain/user/model/User.java
+++ b/src/main/java/com/eod/eod/domain/user/model/User.java
@@ -67,6 +67,10 @@ public class User {
     @Column(name = "discord_id", unique = true, length = 20)
     private String discordId;
 
+    // 물품 픽업 예정 일시
+    @Column(name = "pickup_date")
+    private LocalDateTime pickupDate;
+
     // 계정 생성 일시
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
@@ -126,6 +130,14 @@ public class User {
             return null;
         }
         return grade * 1000 + classNo * 100 + studentNo;
+    }
+
+    public void linkDiscordId(String discordId) {
+        this.discordId = discordId;
+    }
+
+    public void updatePickupDate(LocalDateTime pickupDate) {
+        this.pickupDate = pickupDate;
     }
 
     // 사용자 역할 정의

--- a/src/test/java/com/eod/eod/domain/auth/application/BsmOAuthIntegrationTest.java
+++ b/src/test/java/com/eod/eod/domain/auth/application/BsmOAuthIntegrationTest.java
@@ -1,5 +1,7 @@
 package com.eod.eod.domain.auth.application;
 
+import com.eod.eod.domain.auth.infrastructure.DiscordOAuthStateRepository;
+import com.eod.eod.domain.auth.model.DiscordOAuthState;
 import com.eod.eod.domain.user.infrastructure.UserRepository;
 import com.eod.eod.domain.user.model.User;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -43,6 +45,9 @@ class BsmOAuthIntegrationTest {
     @Autowired
     private UserRepository userRepository;
 
+    @Autowired
+    private DiscordOAuthStateRepository discordOAuthStateRepository;
+
     @MockitoBean
     private BsmOAuthService bsmOAuthService;
 
@@ -57,6 +62,7 @@ class BsmOAuthIntegrationTest {
     void setUp() {
         // 기존 테스트 사용자 정리
         userRepository.deleteAll();
+        discordOAuthStateRepository.deleteAll();
     }
 
     @Test
@@ -76,6 +82,27 @@ class BsmOAuthIntegrationTest {
                 .andExpect(header().string("Location", containsString("state=")))
                 .andExpect(cookie().exists("bsm_oauth_state"))
                 .andExpect(cookie().maxAge("bsm_oauth_state", 300)); // 5분
+    }
+
+    @Test
+    @DisplayName("Discord 봇용 인증 시작 - OAuth URL을 JSON으로 반환하고 state를 저장")
+    void testAuthorizeForDiscordReturnsJsonUrl() throws Exception {
+        String discordId = "123456789012345678";
+        String authorizeUrl = "https://auth.bssm.kro.kr/oauth?clientId=test&redirectURI=http://localhost/callback&state=generated";
+        when(bsmOAuthService.buildAuthorizeUrl(anyString())).thenReturn(authorizeUrl);
+
+        mockMvc.perform(get("/auth/oauth/bsm/authorize/discord")
+                        .param("discordId", discordId))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().json("""
+                        {"url":"https://auth.bssm.kro.kr/oauth?clientId=test&redirectURI=http://localhost/callback&state=generated"}
+                        """));
+
+        long stateCount = discordOAuthStateRepository.findAll().stream()
+                .filter(savedState -> discordId.equals(savedState.getDiscordId()))
+                .count();
+        assert stateCount == 1 : "Discord OAuth state should be saved";
     }
 
     @Test
@@ -175,6 +202,39 @@ class BsmOAuthIntegrationTest {
         assert updatedUser.getClassNo().equals(2) : "ClassNo should be updated from BSM";
         assert updatedUser.getStudentNo().equals(3) : "StudentNo should be updated from BSM";
         assert updatedUser.getIsGraduate().equals(false) : "IsGraduate should be updated from BSM";
+    }
+
+    @Test
+    @DisplayName("콜백 성공 - Discord state로 사용자 discordId 연결")
+    void testCallbackLinksDiscordId() throws Exception {
+        String discordId = "123456789012345678";
+        discordOAuthStateRepository.save(new DiscordOAuthState(TEST_STATE, discordId, java.time.LocalDateTime.now().plusMinutes(10)));
+
+        JsonNode mockUserResource = createMockBsmUserResource(
+                "123456",
+                "12345",
+                "홍길동",
+                "hong@bssm.hs.kr"
+        );
+
+        BsmOAuthService.ExchangeResult exchangeResult =
+                new BsmOAuthService.ExchangeResult(TEST_BSM_TOKEN, mockUserResource);
+
+        when(bsmOAuthService.exchangeCode(eq(TEST_CODE), eq(true)))
+                .thenReturn(exchangeResult);
+
+        mockMvc.perform(get("/oauth/bsm")
+                        .param("code", TEST_CODE)
+                        .param("state", TEST_STATE))
+                .andDo(print())
+                .andExpect(status().isFound())
+                .andExpect(header().string("Location", containsString("auth/callback")))
+                .andExpect(cookie().exists("refreshToken"));
+
+        User savedUser = userRepository.findByOauthProviderAndOauthId("bsm", "123456")
+                .orElseThrow(() -> new AssertionError("User should be saved"));
+        assert discordId.equals(savedUser.getDiscordId()) : "Discord ID should be linked";
+        assert discordOAuthStateRepository.findById(TEST_STATE).isEmpty() : "Discord OAuth state should be consumed";
     }
 
     @Test

--- a/src/test/java/com/eod/eod/domain/discord/application/DiscordVerifyServiceTest.java
+++ b/src/test/java/com/eod/eod/domain/discord/application/DiscordVerifyServiceTest.java
@@ -1,0 +1,197 @@
+package com.eod.eod.domain.discord.application;
+
+import com.eod.eod.domain.discord.presentation.dto.request.DiscordVerifyRequest;
+import com.eod.eod.domain.discord.presentation.dto.response.DiscordVerifyResponse;
+import com.eod.eod.domain.user.infrastructure.UserRepository;
+import com.eod.eod.domain.user.model.User;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DiscordVerifyServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private DiscordVerifyService discordVerifyService;
+
+    @Test
+    void verifyUpdatesDiscordIdWithFirstMatchedStudent() {
+        User firstStudent = createUser("김현호", 3, 1, 1);
+        DiscordVerifyRequest request = new DiscordVerifyRequest("3101", "4기_김현호", "123456789012345678");
+
+        when(userRepository.findByName("김현호")).thenReturn(List.of(firstStudent));
+        when(userRepository.findByDiscordId("123456789012345678")).thenReturn(Optional.empty());
+
+        DiscordVerifyResponse response = discordVerifyService.verify(request);
+
+        assertEquals("123456789012345678", firstStudent.getDiscordId());
+        assertEquals("verified", response.status());
+    }
+
+    @Test
+    void verifyThrowsWhenNicknameFormatIsInvalid() {
+        DiscordVerifyRequest request = new DiscordVerifyRequest(null, "4기김현호", "123456789012345678");
+
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> discordVerifyService.verify(request));
+
+        assertEquals("닉네임 형식이 올바르지 않습니다. `4기_김현호` 형식으로 입력해주세요.", exception.getMessage());
+    }
+
+    @Test
+    void verifyThrowsWhenStudentNotFound() {
+        DiscordVerifyRequest request = new DiscordVerifyRequest(null, "4기_김현호", "123456789012345678");
+
+        when(userRepository.findByName("김현호")).thenReturn(List.of());
+
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> discordVerifyService.verify(request));
+
+        assertEquals("일치하는 학생 정보를 찾을 수 없습니다.", exception.getMessage());
+    }
+
+    @Test
+    void verifyThrowsDuplicateWhenMultipleStudentsExistWithoutStudentId() {
+        User firstStudent = createUser("김현호", 3, 1, 1);
+        User secondStudent = createUser("김현호", 3, 1, 2);
+        DiscordVerifyRequest request = new DiscordVerifyRequest(null, "4기_김현호", "123456789012345678");
+
+        when(userRepository.findByName("김현호")).thenReturn(List.of(firstStudent, secondStudent));
+
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> discordVerifyService.verify(request));
+
+        assertEquals("동명이인이 있어 학번 입력이 필요합니다.", exception.getMessage());
+    }
+
+    @Test
+    void verifyResolvesStudentByCohortGradeWithoutStudentId() {
+        User fourthCohortStudent = createUser("김현호", 3, 1, 1);
+        User fifthCohortStudent = createUser("김현호", 2, 1, 1);
+        DiscordVerifyRequest request = new DiscordVerifyRequest(null, "4기_김현호", "123456789012345678");
+
+        when(userRepository.findByName("김현호")).thenReturn(List.of(fourthCohortStudent, fifthCohortStudent));
+        when(userRepository.findByDiscordId("123456789012345678")).thenReturn(Optional.empty());
+
+        DiscordVerifyResponse response = discordVerifyService.verify(request);
+
+        assertEquals("123456789012345678", fourthCohortStudent.getDiscordId());
+        assertEquals(null, fifthCohortStudent.getDiscordId());
+        assertEquals("verified", response.status());
+    }
+
+    @Test
+    void verifyThrowsWhenNoStudentMatchesKnownCohortGrade() {
+        User fifthCohortStudent = createUser("김현호", 2, 1, 1);
+        DiscordVerifyRequest request = new DiscordVerifyRequest(null, "4기_김현호", "123456789012345678");
+
+        when(userRepository.findByName("김현호")).thenReturn(List.of(fifthCohortStudent));
+
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> discordVerifyService.verify(request));
+
+        assertEquals("일치하는 학생 정보를 찾을 수 없습니다.", exception.getMessage());
+    }
+
+    @Test
+    void verifyUpdatesDiscordIdWhenStudentIdMatchesAmongDuplicates() {
+        User firstStudent = createUser("김현호", 3, 1, 1);
+        User secondStudent = createUser("김현호", 3, 1, 2);
+        DiscordVerifyRequest request = new DiscordVerifyRequest("3102", "4기_김현호", "123456789012345678");
+
+        when(userRepository.findByName("김현호")).thenReturn(List.of(firstStudent, secondStudent));
+        when(userRepository.findByDiscordId("123456789012345678")).thenReturn(Optional.empty());
+
+        DiscordVerifyResponse response = discordVerifyService.verify(request);
+
+        assertEquals(null, firstStudent.getDiscordId());
+        assertEquals("123456789012345678", secondStudent.getDiscordId());
+        assertEquals("verified", response.status());
+    }
+
+    @Test
+    void verifyThrowsWhenStudentIdDoesNotMatchAnyDuplicate() {
+        User firstStudent = createUser("김현호", 3, 1, 1);
+        User secondStudent = createUser("김현호", 3, 1, 2);
+        DiscordVerifyRequest request = new DiscordVerifyRequest("3103", "4기_김현호", "123456789012345678");
+
+        when(userRepository.findByName("김현호")).thenReturn(List.of(firstStudent, secondStudent));
+
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> discordVerifyService.verify(request));
+
+        assertEquals("입력한 학번과 닉네임 정보가 일치하지 않습니다.", exception.getMessage());
+    }
+
+    @Test
+    void verifyReturnsAlreadyVerifiedWhenSameDiscordIdIsLinked() {
+        User student = createUser("김현호", 3, 1, 1);
+        student.updateDiscordId("123456789012345678");
+        DiscordVerifyRequest request = new DiscordVerifyRequest(null, "4기_김현호", "123456789012345678");
+
+        when(userRepository.findByName("김현호")).thenReturn(List.of(student));
+
+        DiscordVerifyResponse response = discordVerifyService.verify(request);
+
+        assertEquals("already_verified", response.status());
+        assertEquals("이미 인증된 계정입니다.", response.message());
+    }
+
+    @Test
+    void verifyThrowsWhenStudentIsLinkedToAnotherDiscordId() {
+        User student = createUser("김현호", 3, 1, 1);
+        student.updateDiscordId("999999999999999999");
+        DiscordVerifyRequest request = new DiscordVerifyRequest(null, "4기_김현호", "123456789012345678");
+
+        when(userRepository.findByName("김현호")).thenReturn(List.of(student));
+
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> discordVerifyService.verify(request));
+
+        assertEquals("이미 다른 디스코드 계정에 연결된 학생입니다.", exception.getMessage());
+    }
+
+    @Test
+    void verifyThrowsWhenDiscordUserIdIsAlreadyAssignedToAnotherStudent() {
+        User targetStudent = createUser("김현호", 3, 1, 1);
+        User linkedStudent = createUser("이민지", 3, 1, 5);
+        ReflectionTestUtils.setField(targetStudent, "id", 1L);
+        ReflectionTestUtils.setField(linkedStudent, "id", 2L);
+        linkedStudent.updateDiscordId("123456789012345678");
+        DiscordVerifyRequest request = new DiscordVerifyRequest(null, "4기_김현호", "123456789012345678");
+
+        when(userRepository.findByName("김현호")).thenReturn(List.of(targetStudent));
+        when(userRepository.findByDiscordId("123456789012345678")).thenReturn(Optional.of(linkedStudent));
+
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> discordVerifyService.verify(request));
+
+        assertEquals("이미 다른 학생에 연결된 디스코드 계정입니다.", exception.getMessage());
+    }
+
+    private User createUser(String name, int grade, int classNo, int studentNo) {
+        return User.builder()
+                .name(name)
+                .grade(grade)
+                .classNo(classNo)
+                .studentNo(studentNo)
+                .oauthProvider("bsm")
+                .oauthId("oauth-id-" + studentNo)
+                .email("student" + studentNo + "@example.com")
+                .role(User.Role.USER)
+                .build();
+    }
+}


### PR DESCRIPTION
## 📋 요약
Discord 인증 도메인 추가 및 User 엔티티 연동

## 🔗 관련 이슈
close #269

## 🔄 변경 사항
- [x] 새로운 기능 추가

### 변경된 내용
- Discord 인증 도메인 추가 (`DiscordVerifyService`, `DiscordController`, `DiscordVerifyException` 등)
- `User` 엔티티에 `discord_id` 필드 추가 (`unique = true`, `length = 20`)
- `UserRepository`에 `findByDiscordId`, `findByName` 쿼리 추가
- `SecurityConfig`에 `POST /discord/verify` 엔드포인트 인증 없이 허용

### 변경 이유
Discord 봇과 서버 간 사용자 인증 연동을 위해 Discord ID를 User 엔티티에 저장하고, 인증 전용 엔드포인트를 제공해야 했음

## ✅ 체크리스트
- [ ] 코드 리뷰 완료
- [ ] 테스트 통과
- [ ] 문서 업데이트 (필요한 경우)
- [x] 브레이킹 체인지 확인
  - `users` 테이블에 `discord_id` 컬럼이 추가됨 → **DB 마이그레이션 필요** (기존 row는 `NULL`로 처리되므로 서비스 중단 없이 적용 가능)
  - `POST /discord/verify` 엔드포인트 신규 추가 (기존 API 영향 없음)