### PR TITLE
로그 모니터링 스택 추가

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -15,7 +15,7 @@ services:
       - JWT_SECRET=${JWT_SECRET}
       - BASE_URL=${BASE_URL}
       - FRONTEND_BASE_URL=${FRONTEND_BASE_URL}
-      - LOG_DIR=${LOG_DIR}
+      - LOG_DIR=${LOG_DIR:-/logs}
       - BSM_CLIENT_ID=${BSM_CLIENT_ID}
       - BSM_CLIENT_SECRET=${BSM_CLIENT_SECRET}
       - BSM_OAUTH_BASE_URL=${BSM_OAUTH_BASE_URL}
@@ -78,8 +78,43 @@ services:
     networks:
       - eod-network
 
+  loki:
+    image: grafana/loki:3.7.0
+    container_name: eod-loki
+    restart: always
+    command:
+      - -config.file=/etc/loki/loki-config.yml
+    volumes:
+      - ./monitoring/loki/loki-config.yml:/etc/loki/loki-config.yml:ro
+      - loki-data-prod:/loki
+    networks:
+      - eod-network
+
+  alloy:
+    image: grafana/alloy:v1.11.3
+    container_name: eod-alloy
+    restart: always
+    command:
+      - run
+      - --server.http.listen-addr=0.0.0.0:12345
+      - --storage.path=/var/lib/alloy
+      - /etc/alloy/config.alloy
+    environment:
+      - SERVER_NAME=eod-prod-01
+      - ENVIRONMENT=prod
+      - APP_CONTAINER_NAME=eod-app
+    volumes:
+      - ./monitoring/alloy/config.alloy:/etc/alloy/config.alloy:ro
+      - /eod/prod/logs:/var/log/eod:ro
+      - alloy-data-prod:/var/lib/alloy
+    depends_on:
+      loki:
+        condition: service_started
+    networks:
+      - eod-network
+
   grafana:
-    image: grafana/grafana:11.1.0
+    image: grafana/grafana:12.4.0
     container_name: eod-grafana
     restart: always
     ports:
@@ -94,6 +129,8 @@ services:
     depends_on:
       prometheus:
         condition: service_started
+      loki:
+        condition: service_started
     networks:
       - eod-network
 
@@ -101,6 +138,10 @@ volumes:
   mysql-data-prod:
     external: true
     name: eod_mysql-data-prod
+  loki-data-prod:
+    name: eod_loki-data-prod
+  alloy-data-prod:
+    name: eod_alloy-data-prod
 
 networks:
   eod-network:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -67,6 +67,58 @@ services:
     networks:
       - eod-network
 
+  node-exporter:
+    image: prom/node-exporter:v1.9.1
+    container_name: eod-node-exporter
+    restart: always
+    command:
+      - --path.rootfs=/host
+    pid: host
+    volumes:
+      - /:/host:ro,rslave
+    networks:
+      - eod-network
+
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:v0.52.1
+    container_name: eod-cadvisor
+    restart: always
+    privileged: true
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker:/var/lib/docker:ro
+      - /dev/disk:/dev/disk:ro
+    networks:
+      - eod-network
+
+  mysqld-exporter:
+    image: prom/mysqld-exporter:v0.19.0
+    container_name: eod-mysqld-exporter
+    restart: always
+    command:
+      - --mysqld.address=mysql:3306
+      - --mysqld.username=${MYSQL_USER}
+    environment:
+      - MYSQLD_EXPORTER_PASSWORD=${MYSQL_PASSWORD}
+    depends_on:
+      mysql:
+        condition: service_healthy
+    networks:
+      - eod-network
+
+  blackbox-exporter:
+    image: prom/blackbox-exporter:v0.27.0
+    container_name: eod-blackbox-exporter
+    restart: always
+    command:
+      - --config.file=/etc/blackbox/blackbox.yml
+    volumes:
+      - ./monitoring/blackbox/blackbox.yml:/etc/blackbox/blackbox.yml:ro
+    networks:
+      - eod-network
+
   alertmanager:
     image: prom/alertmanager:v0.27.0
     container_name: eod-alertmanager
@@ -122,6 +174,7 @@ services:
     environment:
       - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:?GRAFANA_ADMIN_USER is required}
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:?GRAFANA_ADMIN_PASSWORD is required}
+      - GF_METRICS_ENABLED=true
     volumes:
       - ./monitoring/grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro
       - ./monitoring/grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,60 @@ services:
     networks:
       - eod-network-dev
 
+  node-exporter:
+    image: prom/node-exporter:v1.9.1
+    container_name: eod-node-exporter-dev
+    restart: always
+    command:
+      - --path.rootfs=/host
+    pid: host
+    volumes:
+      - /:/host:ro,rslave
+    networks:
+      - eod-network-dev
+
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:v0.52.1
+    container_name: eod-cadvisor-dev
+    restart: always
+    privileged: true
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker:/var/lib/docker:ro
+      - /dev/disk:/dev/disk:ro
+    networks:
+      - eod-network-dev
+
+  mysqld-exporter:
+    image: prom/mysqld-exporter:v0.19.0
+    container_name: eod-mysqld-exporter-dev
+    restart: always
+    command:
+      - --mysqld.address=mysql:3306
+      - --mysqld.username=${MYSQL_USER}
+    environment:
+      - MYSQLD_EXPORTER_PASSWORD=${MYSQL_PASSWORD}
+    depends_on:
+      mysql:
+        condition: service_healthy
+    networks:
+      - eod-network-dev
+
+  blackbox-exporter:
+    image: prom/blackbox-exporter:v0.27.0
+    container_name: eod-blackbox-exporter-dev
+    restart: always
+    command:
+      - --config.file=/etc/blackbox/blackbox.yml
+    ports:
+      - "127.0.0.1:9115:9115"
+    volumes:
+      - ./monitoring/blackbox/blackbox.yml:/etc/blackbox/blackbox.yml:ro
+    networks:
+      - eod-network-dev
+
   loki:
     image: grafana/loki:3.7.0
     container_name: eod-loki-dev
@@ -109,6 +163,7 @@ services:
     environment:
       - GF_SECURITY_ADMIN_USER=admin
       - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_METRICS_ENABLED=true
     volumes:
       - ./monitoring/grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro
       - ./monitoring/grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - JWT_SECRET=${JWT_SECRET}
       - BASE_URL=${BASE_URL}
       - FRONTEND_BASE_URL=${FRONTEND_BASE_URL}
-      - LOG_DIR=${LOG_DIR}
+      - LOG_DIR=${LOG_DIR:-/logs}
       - BSM_CLIENT_ID=${BSM_CLIENT_ID}
       - BSM_CLIENT_SECRET=${BSM_CLIENT_SECRET}
       - BSM_OAUTH_BASE_URL=${BSM_OAUTH_BASE_URL}
@@ -63,8 +63,45 @@ services:
     networks:
       - eod-network-dev
 
+  loki:
+    image: grafana/loki:3.7.0
+    container_name: eod-loki-dev
+    restart: always
+    command:
+      - -config.file=/etc/loki/loki-config.yml
+    ports:
+      - "127.0.0.1:3100:3100"
+    volumes:
+      - ./monitoring/loki/loki-config.yml:/etc/loki/loki-config.yml:ro
+      - loki-data-dev:/loki
+    networks:
+      - eod-network-dev
+
+  alloy:
+    image: grafana/alloy:v1.11.3
+    container_name: eod-alloy-dev
+    restart: always
+    command:
+      - run
+      - --server.http.listen-addr=0.0.0.0:12345
+      - --storage.path=/var/lib/alloy
+      - /etc/alloy/config.alloy
+    environment:
+      - SERVER_NAME=${SERVER_NAME:-local-dev}
+      - ENVIRONMENT=${ENVIRONMENT:-dev}
+      - APP_CONTAINER_NAME=eod-app-dev
+    volumes:
+      - ./monitoring/alloy/config.alloy:/etc/alloy/config.alloy:ro
+      - /eod/logs:/var/log/eod:ro
+      - alloy-data-dev:/var/lib/alloy
+    depends_on:
+      loki:
+        condition: service_started
+    networks:
+      - eod-network-dev
+
   grafana:
-    image: grafana/grafana:11.1.0
+    image: grafana/grafana:12.4.0
     container_name: eod-grafana-dev
     restart: always
     ports:
@@ -79,6 +116,8 @@ services:
     depends_on:
       prometheus:
         condition: service_started
+      loki:
+        condition: service_started
     networks:
       - eod-network-dev
 
@@ -86,6 +125,10 @@ volumes:
   mysql-data-dev:
     external: true
     name: eod_mysql-data-dev
+  loki-data-dev:
+    name: eod_loki-data-dev
+  alloy-data-dev:
+    name: eod_alloy-data-dev
 
 networks:
   eod-network-dev:

--- a/docs/superpowers/plans/2026-05-03-drilldown-logs.md
+++ b/docs/superpowers/plans/2026-05-03-drilldown-logs.md
@@ -1,0 +1,715 @@
+# Grafana Logs Drilldown Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add server-filterable application logs to the existing Docker Compose monitoring stack so Grafana Logs Drilldown can browse EOD backend logs without writing LogQL.
+
+**Architecture:** Keep the current Prometheus/Grafana stack and add Loki as the log store plus Grafana Alloy as the file log collector. Alloy tails the existing Spring Boot file logs from `/logs`, attaches stable labels such as `service_name`, `server`, `env`, and `container`, and pushes entries to Loki over the private Docker network. Grafana provisions Loki as an additional datasource and runs a Grafana version where Logs Drilldown is available.
+
+**Tech Stack:** Docker Compose, Grafana 12.x or Grafana >= 11.6.11, Loki 3.x, Grafana Alloy, Spring Boot Logback.
+
+---
+
+## Current State
+
+- `docker-compose.prod.yml` already runs `app`, `mysql`, `prometheus`, `alertmanager`, and `grafana`.
+- `docker-compose.prod.yml` mounts app logs from host `/eod/prod/logs` into the app container as `/logs`.
+- `src/main/resources/logback-spring.xml` writes `${LOG_DIR}/application.log` and gzipped rotated files.
+- `monitoring/grafana/provisioning/datasources/prometheus.yml` provisions only Prometheus.
+- There is no Loki service, Alloy service, Loki datasource, or Logs Drilldown-specific Loki configuration.
+
+## External Requirements
+
+- Grafana Logs Drilldown supports only Loki datasources.
+- Grafana Logs Drilldown is installed by default in Grafana `v11.6.11` and later; Grafana `v12` includes Drilldown apps in the navigation.
+- Loki must expose log volume data for Drilldown. Set `limits_config.volume_enabled: true`.
+- For useful service selection, logs need a stable service label. Use `service_name="eod-backend"` and set Loki `limits_config.discover_service_name`.
+- For server-by-server filtering, Alloy must attach `server="${SERVER_NAME}"`.
+
+## File Structure
+
+- Modify: `docker-compose.prod.yml`
+  - Upgrade Grafana image.
+  - Add `loki` service.
+  - Add `alloy` service.
+  - Add `loki-data-prod` and `alloy-data-prod` volumes.
+  - Pass `SERVER_NAME` and `ENVIRONMENT` to Alloy.
+
+- Modify: `docker-compose.yml`
+  - Mirror the local/dev version of Loki and Alloy.
+  - Use `SERVER_NAME=${SERVER_NAME:-local-dev}` and `ENVIRONMENT=${ENVIRONMENT:-dev}` defaults.
+
+- Create: `monitoring/loki/loki-config.yml`
+  - Single-binary filesystem-backed Loki config for Docker Compose.
+  - Enable `volume_enabled`.
+  - Set `discover_service_name`.
+  - Keep Loki internal-only.
+
+- Create: `monitoring/alloy/config.alloy`
+  - Tail `/var/log/eod/application.log`.
+  - Attach labels required by Drilldown.
+  - Parse the current Logback text format enough to extract `level`, `thread`, and `logger`.
+  - Forward logs to `http://loki:3100/loki/api/v1/push`.
+
+- Modify or rename: `monitoring/grafana/provisioning/datasources/prometheus.yml`
+  - Either keep the filename and add Loki to the same provisioning file, or rename to `datasources.yml`.
+  - Preserve Prometheus as the default datasource.
+  - Add Loki with uid `loki`.
+
+- Modify: `monitoring/README.md`
+  - Document the logs architecture, required env vars, access path, and smoke-test commands.
+
+- Optional later modify: `src/main/resources/logback-spring.xml`
+  - Keep out of the first pass unless parsing proves brittle.
+  - Future improvement: switch file log output to JSON for cleaner fields.
+
+---
+
+## Chunk 1: Baseline Verification
+
+### Task 1: Confirm Current Compose and Log Paths
+
+**Files:**
+- Read: `docker-compose.prod.yml`
+- Read: `docker-compose.yml`
+- Read: `src/main/resources/logback-spring.xml`
+- Read: `monitoring/grafana/provisioning/datasources/prometheus.yml`
+
+- [ ] **Step 1: Verify current services**
+
+Run:
+
+```bash
+docker compose -f docker-compose.prod.yml config --services
+```
+
+Expected: output includes `app`, `mysql`, `prometheus`, `alertmanager`, `grafana`; does not include `loki` or `alloy`.
+
+- [ ] **Step 2: Verify app log path contract**
+
+Run:
+
+```bash
+rg -n "LOG_DIR|application.log|/logs|/eod/prod/logs" docker-compose.prod.yml src/main/resources/logback-spring.xml
+```
+
+Expected: app mounts `/eod/prod/logs:/logs`, and Logback writes `${LOG_DIR}/application.log`.
+
+- [ ] **Step 3: Commit is not required**
+
+No code changes in this task.
+
+---
+
+## Chunk 2: Loki Storage
+
+### Task 2: Add Loki Configuration
+
+**Files:**
+- Create: `monitoring/loki/loki-config.yml`
+
+- [ ] **Step 1: Create Loki config**
+
+Create `monitoring/loki/loki-config.yml`:
+
+```yaml
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9095
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+query_range:
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true
+        max_size_mb: 100
+
+schema_config:
+  configs:
+    - from: 2024-04-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  volume_enabled: true
+  discover_service_name:
+    - service_name
+    - app
+    - job
+
+analytics:
+  reporting_enabled: false
+```
+
+- [ ] **Step 2: Validate YAML parses**
+
+Run:
+
+```bash
+ruby -e 'require "yaml"; YAML.load_file("monitoring/loki/loki-config.yml"); puts "ok"'
+```
+
+Expected: `ok`.
+
+- [ ] **Step 3: Commit**
+
+Run:
+
+```bash
+git add monitoring/loki/loki-config.yml
+git commit -m "infra: add loki config for logs drilldown"
+```
+
+---
+
+## Chunk 3: Alloy Log Collection
+
+### Task 3: Add Alloy File Tailer
+
+**Files:**
+- Create: `monitoring/alloy/config.alloy`
+
+- [ ] **Step 1: Create Alloy config**
+
+Create `monitoring/alloy/config.alloy`:
+
+```river
+loki.source.file "eod_app" {
+  targets = [
+    {
+      __path__      = "/var/log/eod/application.log",
+      service_name  = "eod-backend",
+      app           = "eod",
+      env           = sys.env("ENVIRONMENT"),
+      server        = sys.env("SERVER_NAME"),
+      container     = "eod-app",
+      log_source    = "spring-file",
+    },
+  ]
+
+  forward_to = [loki.process.eod_app.receiver]
+}
+
+loki.process "eod_app" {
+  stage.regex {
+    expression = "^(?P<timestamp>\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d{3}) (?P<level>[A-Z]+)\\s+\\[(?P<thread>[^\\]]+)\\] (?P<logger>[^ ]+) - (?P<message>.*)$"
+  }
+
+  stage.labels {
+    values = {
+      level = "",
+    }
+  }
+
+  stage.structured_metadata {
+    values = {
+      thread = "",
+      logger = "",
+    }
+  }
+
+  forward_to = [loki.write.local.receiver]
+}
+
+loki.write "local" {
+  endpoint {
+    url = "http://loki:3100/loki/api/v1/push"
+  }
+}
+```
+
+- [ ] **Step 2: Validate Alloy config in container**
+
+Run:
+
+```bash
+docker run --rm \
+  -v "$PWD/monitoring/alloy/config.alloy:/etc/alloy/config.alloy:ro" \
+  grafana/alloy:latest \
+  run --server.http.listen-addr=127.0.0.1:12345 --storage.path=/tmp/alloy /etc/alloy/config.alloy
+```
+
+Expected: Alloy starts without a River parse error. Stop it with `Ctrl+C` after confirming startup.
+
+- [ ] **Step 3: Commit**
+
+Run:
+
+```bash
+git add monitoring/alloy/config.alloy
+git commit -m "infra: collect app file logs with alloy"
+```
+
+---
+
+## Chunk 4: Docker Compose Integration
+
+### Task 4: Wire Loki and Alloy into Production Compose
+
+**Files:**
+- Modify: `docker-compose.prod.yml`
+
+- [ ] **Step 1: Upgrade Grafana image**
+
+Change:
+
+```yaml
+image: grafana/grafana:11.1.0
+```
+
+To a current pinned Grafana 12 image after checking availability during implementation, for example:
+
+```yaml
+image: grafana/grafana:12.4.0
+```
+
+If `12.4.0` is not available at implementation time, use the latest stable `12.x` image. Do not use `latest`.
+
+- [ ] **Step 2: Add Loki service after Alertmanager**
+
+Add:
+
+```yaml
+  loki:
+    image: grafana/loki:3.7.0
+    container_name: eod-loki
+    restart: always
+    command:
+      - -config.file=/etc/loki/loki-config.yml
+    volumes:
+      - ./monitoring/loki/loki-config.yml:/etc/loki/loki-config.yml:ro
+      - loki-data-prod:/loki
+    networks:
+      - eod-network
+```
+
+Do not publish `3100` externally in production.
+
+- [ ] **Step 3: Add Alloy service after Loki**
+
+Add:
+
+```yaml
+  alloy:
+    image: grafana/alloy:latest
+    container_name: eod-alloy
+    restart: always
+    command:
+      - run
+      - --server.http.listen-addr=0.0.0.0:12345
+      - --storage.path=/var/lib/alloy
+      - /etc/alloy/config.alloy
+    environment:
+      - SERVER_NAME=${SERVER_NAME:?SERVER_NAME is required}
+      - ENVIRONMENT=${ENVIRONMENT:-prod}
+    volumes:
+      - ./monitoring/alloy/config.alloy:/etc/alloy/config.alloy:ro
+      - /eod/prod/logs:/var/log/eod:ro
+      - alloy-data-prod:/var/lib/alloy
+    depends_on:
+      loki:
+        condition: service_started
+    networks:
+      - eod-network
+```
+
+Implementation note: replace `grafana/alloy:latest` with a pinned current Alloy version if the team wants fully reproducible deployments.
+
+- [ ] **Step 4: Make Grafana depend on Loki**
+
+Change Grafana `depends_on` to include Loki:
+
+```yaml
+    depends_on:
+      prometheus:
+        condition: service_started
+      loki:
+        condition: service_started
+```
+
+- [ ] **Step 5: Add volumes**
+
+Add under `volumes`:
+
+```yaml
+  loki-data-prod:
+    name: eod_loki-data-prod
+  alloy-data-prod:
+    name: eod_alloy-data-prod
+```
+
+- [ ] **Step 6: Validate production compose**
+
+Run:
+
+```bash
+docker compose -f docker-compose.prod.yml config
+```
+
+Expected: config renders successfully when required env vars are supplied. If local shell lacks required prod vars, run with temporary non-secret placeholders:
+
+```bash
+GRAFANA_ADMIN_USER=admin \
+GRAFANA_ADMIN_PASSWORD=placeholder \
+SERVER_NAME=eod-prod-01 \
+SPRING_DATASOURCE_URL=jdbc:mysql://mysql:3306/eod \
+SPRING_DATASOURCE_USERNAME=eod \
+SPRING_DATASOURCE_PASSWORD=placeholder \
+JWT_SECRET=placeholder \
+BASE_URL=https://example.com \
+FRONTEND_BASE_URL=https://example.com \
+LOG_DIR=/logs \
+BSM_CLIENT_ID=placeholder \
+BSM_CLIENT_SECRET=placeholder \
+BSM_OAUTH_BASE_URL=https://auth.bssm.app \
+BSM_REDIRECT_URI=https://example.com/oauth/bsm \
+FILE_UPLOAD_BASE_URL=https://example.com \
+MYSQL_ROOT_PASSWORD=placeholder \
+MYSQL_DATABASE=eod \
+MYSQL_USER=eod \
+MYSQL_PASSWORD=placeholder \
+DISCORD_WEBHOOK_URL=https://example.com/webhook \
+docker compose -f docker-compose.prod.yml config >/tmp/eod-compose-prod.yml
+```
+
+- [ ] **Step 7: Commit**
+
+Run:
+
+```bash
+git add docker-compose.prod.yml
+git commit -m "infra: add loki and alloy to production compose"
+```
+
+### Task 5: Mirror Loki and Alloy in Dev Compose
+
+**Files:**
+- Modify: `docker-compose.yml`
+
+- [ ] **Step 1: Add Loki service**
+
+Use the same Loki service as production, but name the container `eod-loki-dev` and use volume `loki-data-dev`.
+
+- [ ] **Step 2: Add Alloy service**
+
+Use the same Alloy service as production, but:
+
+```yaml
+container_name: eod-alloy-dev
+environment:
+  - SERVER_NAME=${SERVER_NAME:-local-dev}
+  - ENVIRONMENT=${ENVIRONMENT:-dev}
+volumes:
+  - ./monitoring/alloy/config.alloy:/etc/alloy/config.alloy:ro
+  - /eod/logs:/var/log/eod:ro
+  - alloy-data-dev:/var/lib/alloy
+```
+
+- [ ] **Step 3: Upgrade dev Grafana image**
+
+Use the same Grafana version as production.
+
+- [ ] **Step 4: Add dev volumes**
+
+Add:
+
+```yaml
+  loki-data-dev:
+    name: eod_loki-data-dev
+  alloy-data-dev:
+    name: eod_alloy-data-dev
+```
+
+- [ ] **Step 5: Validate dev compose**
+
+Run:
+
+```bash
+docker compose -f docker-compose.yml config
+```
+
+Expected: config renders successfully with existing dev defaults plus any required app env vars.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```bash
+git add docker-compose.yml
+git commit -m "infra: add loki and alloy to dev compose"
+```
+
+---
+
+## Chunk 5: Grafana Datasource and Drilldown
+
+### Task 6: Provision Loki Datasource
+
+**Files:**
+- Modify: `monitoring/grafana/provisioning/datasources/prometheus.yml`
+
+- [ ] **Step 1: Add Loki datasource**
+
+Keep Prometheus as default and add:
+
+```yaml
+  - name: Loki
+    uid: loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    isDefault: false
+    editable: true
+    jsonData:
+      maxLines: 1000
+```
+
+- [ ] **Step 2: Validate YAML parses**
+
+Run:
+
+```bash
+ruby -e 'require "yaml"; YAML.load_file("monitoring/grafana/provisioning/datasources/prometheus.yml"); puts "ok"'
+```
+
+Expected: `ok`.
+
+- [ ] **Step 3: Commit**
+
+Run:
+
+```bash
+git add monitoring/grafana/provisioning/datasources/prometheus.yml
+git commit -m "infra: provision loki datasource in grafana"
+```
+
+### Task 7: Smoke Test Drilldown Locally
+
+**Files:**
+- No expected file changes.
+
+- [ ] **Step 1: Ensure local log directory exists**
+
+Run:
+
+```bash
+sudo mkdir -p /eod/logs
+sudo chown "$USER" /eod/logs
+printf '2026-05-03 12:00:00.000 INFO  [main] com.eod.eod.Test - drilldown smoke test\n' >> /eod/logs/application.log
+```
+
+- [ ] **Step 2: Start observability services**
+
+Run:
+
+```bash
+docker compose -f docker-compose.yml up -d loki alloy grafana
+```
+
+Expected: `eod-loki-dev`, `eod-alloy-dev`, and `eod-grafana-dev` are running.
+
+- [ ] **Step 3: Verify Loki readiness**
+
+Run:
+
+```bash
+docker compose -f docker-compose.yml exec loki wget -qO- http://localhost:3100/ready
+```
+
+Expected: readiness output indicates Loki is ready.
+
+- [ ] **Step 4: Verify logs reached Loki**
+
+Run:
+
+```bash
+docker compose -f docker-compose.yml exec loki wget -qO- 'http://localhost:3100/loki/api/v1/labels'
+```
+
+Expected: labels include `service_name`, `server`, `env`, `container`, and `level`.
+
+- [ ] **Step 5: Query by server**
+
+Run from the host:
+
+```bash
+curl -G 'http://localhost:3100/loki/api/v1/query_range' \
+  --data-urlencode 'query={service_name="eod-backend",server="local-dev"}' \
+  --data-urlencode 'limit=10'
+```
+
+If Loki is not published to the host in dev, run the equivalent query from inside the Loki container or temporarily publish `3100:3100` only in dev.
+
+Expected: response includes the smoke test log line.
+
+- [ ] **Step 6: Verify in Grafana**
+
+Open `http://localhost:3001`.
+
+Expected:
+
+- Connections > Data sources shows `Loki`.
+- Explore can query `{service_name="eod-backend",server="local-dev"}`.
+- Drilldown > Logs shows `eod-backend` as a service.
+- Filters include `server`, `env`, `container`, and `level`.
+
+---
+
+## Chunk 6: Documentation and Operations
+
+### Task 8: Update Monitoring README
+
+**Files:**
+- Modify: `monitoring/README.md`
+
+- [ ] **Step 1: Add required env vars**
+
+Add:
+
+```markdown
+- `SERVER_NAME`: stable server identifier used as the Loki `server` label, for example `eod-prod-01`.
+- `ENVIRONMENT`: deployment environment used as the Loki `env` label. Defaults to `prod` in production compose.
+```
+
+- [ ] **Step 2: Add logs architecture section**
+
+Add:
+
+````markdown
+## Logs
+
+Application logs are written by Logback to `/logs/application.log` inside the app container. In production, Docker Compose mounts host `/eod/prod/logs` to that path.
+
+Grafana Alloy tails `/eod/prod/logs/application.log` through a read-only mount, parses the current Logback text format, attaches labels, and sends entries to Loki.
+
+Important labels:
+
+- `service_name="eod-backend"`: primary Logs Drilldown service label.
+- `server`: physical or VM server name from `SERVER_NAME`.
+- `env`: deployment environment.
+- `container`: Docker container role.
+- `level`: parsed log severity.
+
+In Grafana, use Drilldown > Logs and select the Loki datasource. For direct LogQL checks, use:
+
+```logql
+{service_name="eod-backend", server="eod-prod-01"}
+```
+````
+
+- [ ] **Step 3: Add smoke-test commands**
+
+Document:
+
+```bash
+docker compose -f docker-compose.prod.yml ps loki alloy grafana
+docker compose -f docker-compose.prod.yml logs --tail=100 alloy
+docker compose -f docker-compose.prod.yml exec loki wget -qO- http://localhost:3100/ready
+```
+
+- [ ] **Step 4: Commit**
+
+Run:
+
+```bash
+git add monitoring/README.md
+git commit -m "docs: document logs drilldown operations"
+```
+
+---
+
+## Chunk 7: Production Rollout
+
+### Task 9: Deploy Safely
+
+**Files:**
+- No expected file changes.
+
+- [ ] **Step 1: Prepare production env**
+
+On the production server, set:
+
+```bash
+SERVER_NAME=eod-prod-01
+ENVIRONMENT=prod
+```
+
+Use the real server name. If there are multiple servers, each server must have a unique stable `SERVER_NAME`.
+
+- [ ] **Step 2: Create host log directory if missing**
+
+Run on the production server:
+
+```bash
+sudo mkdir -p /eod/prod/logs
+```
+
+Expected: directory exists and app can continue writing logs through its existing mount.
+
+- [ ] **Step 3: Pull and start new services**
+
+Run:
+
+```bash
+docker compose -f docker-compose.prod.yml pull grafana loki alloy
+docker compose -f docker-compose.prod.yml up -d grafana loki alloy
+```
+
+Expected: existing app and database remain running; new observability services start.
+
+- [ ] **Step 4: Check Alloy ingestion**
+
+Run:
+
+```bash
+docker compose -f docker-compose.prod.yml logs --tail=100 alloy
+```
+
+Expected: no parse errors, no repeated push errors to Loki.
+
+- [ ] **Step 5: Check Grafana**
+
+Open Grafana on port `3002`.
+
+Expected:
+
+- `Loki` datasource is healthy.
+- Drilldown > Logs is visible.
+- `eod-backend` appears.
+- Filtering by the current `SERVER_NAME` returns logs.
+
+---
+
+## Risks and Decisions
+
+- **Grafana image pin:** Do not stay on `grafana/grafana:11.1.0`; it predates the default Logs Drilldown availability. Use a pinned `12.x` image or at least `11.6.11+`.
+- **Alloy image pin:** The plan shows `grafana/alloy:latest` for initial simplicity, but production should prefer a pinned version after confirming the current stable Alloy tag.
+- **Label cardinality:** Keep labels low-cardinality. Do not label by request id, user id, item id, URL, exception message, or trace id. Put those into structured metadata or log fields instead.
+- **Current text logs:** Regex parsing is acceptable for the first pass. JSON logs are a cleaner follow-up if Drilldown fields need to be richer.
+- **Loki retention:** This plan does not set retention. Add retention only after deciding the target storage window, for example 7, 14, or 30 days.
+- **Security:** Keep Loki internal-only in production. Grafana is already the user-facing access point.
+
+## Source References
+
+- Grafana Logs Drilldown requires a Loki datasource and supports Loki-only default datasource configuration.
+- Grafana Logs Drilldown is default-installed in Grafana `v11.6.11+`; Grafana `v12+` includes Drilldown apps in navigation.
+- Loki Drilldown troubleshooting requires `limits_config.volume_enabled: true` for log volume.
+- Grafana Alloy `loki.source.file` tails files and forwards them to `loki.write`, with built-in file matching and persisted positions.

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -24,8 +24,50 @@ The baseline alert rules cover:
 - HTTP 5xx ratio above 5% for 10 minutes
 - HTTP p95 latency above 1 second for 10 minutes
 - JVM heap usage above 90% for 15 minutes
+- HikariCP pending connections
+- JVM GC pause average above 200ms
+- Public and internal `/healthz` availability
+- Monitoring exporter availability
+- Host CPU, memory, disk, and inode pressure
+- MySQL availability and connection usage
+- BSM login failures
+- Image upload failures
+- Scheduler failures
+- Reward give failures
 
 These rules are defined in `monitoring/prometheus/alerts/eod-alerts.yml` and routed through Alertmanager using the Discord webhook from `DISCORD_WEBHOOK_URL`. During production deployment, the workflow renders `monitoring/alertmanager/generated/alertmanager.yml` with that secret and mounts the generated file into Alertmanager.
+
+## Metrics
+
+The monitoring stack collects metrics from:
+
+- Spring Boot Actuator: HTTP, JVM, HikariCP, and EOD custom domain metrics
+- Node Exporter: host CPU, memory, disk, inode, and network metrics
+- cAdvisor: Docker container resource metrics
+- MySQL Exporter: MySQL health, connections, and server metrics
+- Blackbox Exporter: internal and public HTTP availability checks
+- Loki, Alloy, Grafana, and Prometheus self metrics
+
+The application exposes `GET /healthz` as a lightweight unauthenticated liveness endpoint for HTTP availability checks. It intentionally does not check MySQL; database health is monitored separately through MySQL Exporter and HikariCP metrics.
+
+Dashboard files:
+
+- `monitoring/grafana/dashboards/eod-overview.json`: application HTTP/JVM/DB overview
+- `monitoring/grafana/dashboards/eod-infrastructure.json`: server, container, MySQL, and availability metrics
+- `monitoring/grafana/dashboards/eod-domain-metrics.json`: EOD business/domain metrics
+
+Domain metric names:
+
+- `eod_business_events_total{domain,action,result}`
+- `eod_external_call_seconds{provider,operation,result}`
+- `eod_image_upload_bytes{result}`
+- `eod_image_upload_seconds{result}`
+- `eod_scheduler_runs_total{task,result}`
+- `eod_scheduler_processed_items{task}`
+- `eod_items_current{status}`
+- `eod_claims_current{status}`
+- `eod_reward_eligible_items`
+- `eod_reward_records_current`
 
 ## Logs
 

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -30,10 +30,7 @@ The baseline alert rules cover:
 - Monitoring exporter availability
 - Host CPU, memory, disk, and inode pressure
 - MySQL availability and connection usage
-- BSM login failures
-- Image upload failures
 - Scheduler failures
-- Reward give failures
 
 These rules are defined in `monitoring/prometheus/alerts/eod-alerts.yml` and routed through Alertmanager using the Discord webhook from `DISCORD_WEBHOOK_URL`. During production deployment, the workflow renders `monitoring/alertmanager/generated/alertmanager.yml` with that secret and mounts the generated file into Alertmanager.
 

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -26,3 +26,31 @@ The baseline alert rules cover:
 - JVM heap usage above 90% for 15 minutes
 
 These rules are defined in `monitoring/prometheus/alerts/eod-alerts.yml` and routed through Alertmanager using the Discord webhook from `DISCORD_WEBHOOK_URL`. During production deployment, the workflow renders `monitoring/alertmanager/generated/alertmanager.yml` with that secret and mounts the generated file into Alertmanager.
+
+## Logs
+
+Application logs are written by Logback to `/logs/application.log` inside the app container. In production, `docker-compose.prod.yml` mounts host `/eod/prod/logs` to that path.
+
+Grafana Alloy tails `/eod/prod/logs/application.log` through a read-only mount, parses the current Logback text format, attaches labels, and sends entries to Loki. Loki stays on the internal Docker network; Grafana is the user-facing access point for Explore and Drilldown > Logs.
+
+Important Loki labels:
+
+- `service_name="eod-backend"`: primary service label for Logs Drilldown
+- `server="eod-prod-01"`: production server label configured in `docker-compose.prod.yml`
+- `env="prod"`: production environment label configured in `docker-compose.prod.yml`
+- `container`: Docker container role
+- `level`: parsed log severity
+
+Direct LogQL check:
+
+```logql
+{service_name="eod-backend", server="eod-prod-01"}
+```
+
+Operational checks:
+
+```bash
+docker compose -f docker-compose.prod.yml ps loki alloy grafana
+docker compose -f docker-compose.prod.yml logs --tail=100 alloy
+docker compose -f docker-compose.prod.yml exec loki wget -qO- http://localhost:3100/ready
+```

--- a/monitoring/alloy/config.alloy
+++ b/monitoring/alloy/config.alloy
@@ -1,0 +1,42 @@
+loki.source.file "eod_app" {
+  targets = [
+    {
+      __path__      = "/var/log/eod/application.log",
+      service_name  = "eod-backend",
+      app           = "eod",
+      env           = sys.env("ENVIRONMENT"),
+      server        = sys.env("SERVER_NAME"),
+      container     = sys.env("APP_CONTAINER_NAME"),
+      log_source    = "spring-file",
+    },
+  ]
+
+  forward_to = [loki.process.eod_app.receiver]
+}
+
+loki.process "eod_app" {
+  stage.regex {
+    expression = "^(?P<timestamp>\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d{3}) (?P<level>[A-Z]+)\\s+\\[(?P<thread>[^\\]]+)\\] (?P<logger>[^ ]+) - (?P<message>.*)$"
+  }
+
+  stage.labels {
+    values = {
+      level = "",
+    }
+  }
+
+  stage.structured_metadata {
+    values = {
+      thread = "",
+      logger = "",
+    }
+  }
+
+  forward_to = [loki.write.local.receiver]
+}
+
+loki.write "local" {
+  endpoint {
+    url = "http://loki:3100/loki/api/v1/push"
+  }
+}

--- a/monitoring/blackbox/blackbox.yml
+++ b/monitoring/blackbox/blackbox.yml
@@ -1,0 +1,11 @@
+modules:
+  http_2xx:
+    prober: http
+    timeout: 5s
+    http:
+      valid_http_versions:
+        - HTTP/1.1
+        - HTTP/2.0
+      valid_status_codes: []
+      method: GET
+      preferred_ip_protocol: ip4

--- a/monitoring/grafana/dashboards/eod-domain-metrics.json
+++ b/monitoring/grafana/dashboards/eod-domain-metrics.json
@@ -1,0 +1,604 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (domain, action, result) (increase(eod_business_events_total[5m]))",
+          "legendFormat": "{{ domain }} / {{ action }} / {{ result }}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Business Events",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (domain, action) (increase(eod_business_events_total{result=\"failure\"}[10m]))",
+          "legendFormat": "{{ domain }} / {{ action }}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Business Failures",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "displayMode": "gradient",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "eod_items_current",
+          "legendFormat": "{{ status }}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Items by Status",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "displayMode": "gradient",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "eod_claims_current",
+          "legendFormat": "{{ status }}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Claims by Status",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 8
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "eod_reward_eligible_items",
+          "legendFormat": "eligible",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "eod_reward_records_current",
+          "legendFormat": "records",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Rewards",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, operation, result) (rate(eod_external_call_seconds_bucket[5m])))",
+          "legendFormat": "{{ operation }} / {{ result }}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "BSM External Call P95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 14
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (result) (increase(eod_business_events_total{domain=\"image\",action=\"upload\"}[5m]))",
+          "legendFormat": "{{ result }}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Image Uploads",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 22
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (task, result) (increase(eod_scheduler_runs_total[1h]))",
+          "legendFormat": "{{ task }} / {{ result }}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (task) (increase(eod_scheduler_processed_items_sum[1h]))",
+          "legendFormat": "{{ task }} processed",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Schedulers",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "refresh": "30s",
+  "schemaVersion": 42,
+  "tags": [
+    "eod",
+    "domain"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "EOD Domain Metrics",
+  "uid": "eod-domain-metrics",
+  "version": 1
+}

--- a/monitoring/grafana/dashboards/eod-infrastructure.json
+++ b/monitoring/grafana/dashboards/eod-infrastructure.json
@@ -1,0 +1,591 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "bool_on_off"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "probe_success{job=\"blackbox-http\"}",
+          "legendFormat": "{{ availability_target }}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP Availability",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "100 * (1 - avg(rate(node_cpu_seconds_total{job=\"node-exporter\",mode=\"idle\"}[5m])))",
+          "legendFormat": "cpu",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Host CPU",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "100 * (1 - node_memory_MemAvailable_bytes{job=\"node-exporter\"} / node_memory_MemTotal_bytes{job=\"node-exporter\"})",
+          "legendFormat": "memory",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Host Memory",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 5
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "100 * (1 - node_filesystem_avail_bytes{job=\"node-exporter\",fstype!~\"tmpfs|fuse.lxcfs|overlay\",mountpoint!~\"/run.*|/var/lib/docker/.+\"} / node_filesystem_size_bytes{job=\"node-exporter\",fstype!~\"tmpfs|fuse.lxcfs|overlay\",mountpoint!~\"/run.*|/var/lib/docker/.+\"})",
+          "legendFormat": "{{ mountpoint }}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Disk Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 5
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (name) (rate(container_cpu_usage_seconds_total{job=\"cadvisor\",name!=\"\"}[5m]))",
+          "legendFormat": "{{ name }}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Container CPU",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "bool_on_off"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 13
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "mysql_up{job=\"mysql\"}",
+          "legendFormat": "mysql",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "MySQL Up",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 13
+      },
+      "id": 7,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "100 * mysql_global_status_threads_connected{job=\"mysql\"} / clamp_min(mysql_global_variables_max_connections{job=\"mysql\"}, 1)",
+          "legendFormat": "connections",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "MySQL Connection Usage",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 13
+      },
+      "id": 8,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "up{job=~\"prometheus|node-exporter|cadvisor|mysql|loki|alloy|grafana\"}",
+          "legendFormat": "{{ job }}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Monitoring Targets",
+      "type": "stat"
+    }
+  ],
+  "preload": false,
+  "refresh": "30s",
+  "schemaVersion": 42,
+  "tags": [
+    "eod",
+    "infrastructure"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "EOD Infrastructure",
+  "uid": "eod-infrastructure",
+  "version": 1
+}

--- a/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -8,3 +8,13 @@ datasources:
     url: http://prometheus:9090
     isDefault: true
     editable: true
+
+  - name: Loki
+    uid: loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    isDefault: false
+    editable: true
+    jsonData:
+      maxLines: 1000

--- a/monitoring/loki/loki-config.yml
+++ b/monitoring/loki/loki-config.yml
@@ -1,0 +1,44 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9095
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+query_range:
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true
+        max_size_mb: 100
+
+schema_config:
+  configs:
+    - from: 2024-04-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  volume_enabled: true
+  discover_service_name:
+    - service_name
+    - app
+    - job
+
+analytics:
+  reporting_enabled: false

--- a/monitoring/prometheus/alerts/eod-alerts.yml
+++ b/monitoring/prometheus/alerts/eod-alerts.yml
@@ -80,26 +80,6 @@ groups:
           summary: EOD JVM GC pause is elevated
           description: Average JVM GC pause has stayed above 200ms for 10 minutes.
 
-      - alert: EodBsmLoginFailures
-        expr: increase(eod_business_events_total{domain="auth",action="bsm_login",result="failure"}[10m]) > 3
-        for: 0m
-        labels:
-          severity: warning
-          service: eod
-        annotations:
-          summary: BSM login failures increased
-          description: More than 3 BSM login failures occurred in 10 minutes.
-
-      - alert: EodImageUploadFailures
-        expr: increase(eod_business_events_total{domain="image",action="upload",result="failure"}[10m]) > 3
-        for: 0m
-        labels:
-          severity: warning
-          service: eod
-        annotations:
-          summary: Image upload failures increased
-          description: More than 3 image upload failures occurred in 10 minutes.
-
       - alert: EodSchedulerFailure
         expr: increase(eod_scheduler_runs_total{result=~"failure|partial_failure"}[1h]) > 0
         for: 0m
@@ -109,16 +89,6 @@ groups:
         annotations:
           summary: EOD scheduled task failed
           description: At least one scheduled task failed or partially failed in the last hour.
-
-      - alert: EodRewardGiveFailures
-        expr: increase(eod_business_events_total{domain="reward",action="give",result="failure"}[10m]) > 0
-        for: 0m
-        labels:
-          severity: warning
-          service: eod
-        annotations:
-          summary: Reward give failed
-          description: At least one reward give operation failed in 10 minutes.
 
   - name: eod-infrastructure
     rules:

--- a/monitoring/prometheus/alerts/eod-alerts.yml
+++ b/monitoring/prometheus/alerts/eod-alerts.yml
@@ -54,3 +54,181 @@ groups:
         annotations:
           summary: EOD JVM heap usage is high
           description: JVM heap usage has exceeded 90% for 15 minutes.
+
+      - alert: EodHikariPendingConnections
+        expr: sum(hikaricp_connections_pending{application="eod"}) > 0
+        for: 5m
+        labels:
+          severity: warning
+          service: eod
+        annotations:
+          summary: EOD HikariCP has pending connections
+          description: At least one request has waited for a DB connection for 5 minutes.
+
+      - alert: EodHighGcPauseAverage
+        expr: |
+          (
+            sum(rate(jvm_gc_pause_seconds_sum{application="eod"}[5m]))
+            /
+            clamp_min(sum(rate(jvm_gc_pause_seconds_count{application="eod"}[5m])), 1)
+          ) > 0.2
+        for: 10m
+        labels:
+          severity: warning
+          service: eod
+        annotations:
+          summary: EOD JVM GC pause is elevated
+          description: Average JVM GC pause has stayed above 200ms for 10 minutes.
+
+      - alert: EodBsmLoginFailures
+        expr: increase(eod_business_events_total{domain="auth",action="bsm_login",result="failure"}[10m]) > 3
+        for: 0m
+        labels:
+          severity: warning
+          service: eod
+        annotations:
+          summary: BSM login failures increased
+          description: More than 3 BSM login failures occurred in 10 minutes.
+
+      - alert: EodImageUploadFailures
+        expr: increase(eod_business_events_total{domain="image",action="upload",result="failure"}[10m]) > 3
+        for: 0m
+        labels:
+          severity: warning
+          service: eod
+        annotations:
+          summary: Image upload failures increased
+          description: More than 3 image upload failures occurred in 10 minutes.
+
+      - alert: EodSchedulerFailure
+        expr: increase(eod_scheduler_runs_total{result=~"failure|partial_failure"}[1h]) > 0
+        for: 0m
+        labels:
+          severity: warning
+          service: eod
+        annotations:
+          summary: EOD scheduled task failed
+          description: At least one scheduled task failed or partially failed in the last hour.
+
+      - alert: EodRewardGiveFailures
+        expr: increase(eod_business_events_total{domain="reward",action="give",result="failure"}[10m]) > 0
+        for: 0m
+        labels:
+          severity: warning
+          service: eod
+        annotations:
+          summary: Reward give failed
+          description: At least one reward give operation failed in 10 minutes.
+
+  - name: eod-infrastructure
+    rules:
+      - alert: EodPublicAvailabilityDown
+        expr: probe_success{job="blackbox-http",availability_target="prod-public"} == 0
+        for: 2m
+        labels:
+          severity: critical
+          service: eod
+        annotations:
+          summary: EOD public endpoint is unavailable
+          description: The public /healthz endpoint has failed for 2 minutes.
+
+      - alert: EodInternalHealthzDown
+        expr: probe_success{job="blackbox-http",availability_target="app-internal"} == 0
+        for: 2m
+        labels:
+          severity: critical
+          service: eod
+        annotations:
+          summary: EOD internal healthz endpoint is unavailable
+          description: The internal app /healthz endpoint has failed for 2 minutes.
+
+      - alert: EodExporterDown
+        expr: up{job=~"node-exporter|cadvisor|mysql|loki|alloy|grafana"} == 0
+        for: 3m
+        labels:
+          severity: warning
+          service: eod
+        annotations:
+          summary: EOD monitoring target is down
+          description: '{{ $labels.job }} target {{ $labels.instance }} has been down for 3 minutes.'
+
+      - alert: EodHostHighCpuUsage
+        expr: |
+          1 - avg(rate(node_cpu_seconds_total{job="node-exporter",mode="idle"}[5m])) > 0.85
+        for: 10m
+        labels:
+          severity: warning
+          service: eod
+        annotations:
+          summary: EOD host CPU usage is high
+          description: Host CPU usage has stayed above 85% for 10 minutes.
+
+      - alert: EodHostLowMemory
+        expr: |
+          (
+            node_memory_MemAvailable_bytes{job="node-exporter"}
+            /
+            node_memory_MemTotal_bytes{job="node-exporter"}
+          ) < 0.10
+        for: 10m
+        labels:
+          severity: warning
+          service: eod
+        annotations:
+          summary: EOD host memory is low
+          description: Host available memory has stayed below 10% for 10 minutes.
+
+      - alert: EodHostDiskAlmostFull
+        expr: |
+          (
+            node_filesystem_avail_bytes{job="node-exporter",fstype!~"tmpfs|fuse.lxcfs|overlay",mountpoint!~"/run.*|/var/lib/docker/.+"}
+            /
+            node_filesystem_size_bytes{job="node-exporter",fstype!~"tmpfs|fuse.lxcfs|overlay",mountpoint!~"/run.*|/var/lib/docker/.+"}
+          ) < 0.15
+        for: 10m
+        labels:
+          severity: warning
+          service: eod
+        annotations:
+          summary: EOD host disk is almost full
+          description: Filesystem {{ $labels.mountpoint }} has less than 15% free space.
+
+      - alert: EodHostInodesAlmostFull
+        expr: |
+          (
+            node_filesystem_files_free{job="node-exporter",fstype!~"tmpfs|fuse.lxcfs|overlay",mountpoint!~"/run.*|/var/lib/docker/.+"}
+            /
+            node_filesystem_files{job="node-exporter",fstype!~"tmpfs|fuse.lxcfs|overlay",mountpoint!~"/run.*|/var/lib/docker/.+"}
+          ) < 0.10
+        for: 10m
+        labels:
+          severity: warning
+          service: eod
+        annotations:
+          summary: EOD host inodes are almost exhausted
+          description: Filesystem {{ $labels.mountpoint }} has less than 10% free inodes.
+
+      - alert: EodMysqlDown
+        expr: mysql_up{job="mysql"} == 0
+        for: 2m
+        labels:
+          severity: critical
+          service: eod
+        annotations:
+          summary: EOD MySQL is down
+          description: MySQL exporter cannot connect to MySQL for 2 minutes.
+
+      - alert: EodMysqlHighConnectionUsage
+        expr: |
+          (
+            mysql_global_status_threads_connected{job="mysql"}
+            /
+            clamp_min(mysql_global_variables_max_connections{job="mysql"}, 1)
+          ) > 0.80
+        for: 10m
+        labels:
+          severity: warning
+          service: eod
+        annotations:
+          summary: EOD MySQL connection usage is high
+          description: MySQL connection usage has stayed above 80% for 10 minutes.

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -30,3 +30,68 @@ scrape_configs:
   - job_name: "prometheus"
     static_configs:
       - targets: ["prometheus:9090"]
+
+  - job_name: "node-exporter"
+    static_configs:
+      - targets: ["node-exporter:9100"]
+        labels:
+          application: eod
+          component: node
+
+  - job_name: "cadvisor"
+    static_configs:
+      - targets: ["cadvisor:8080"]
+        labels:
+          application: eod
+          component: containers
+
+  - job_name: "mysql"
+    static_configs:
+      - targets: ["mysqld-exporter:9104"]
+        labels:
+          application: eod
+          component: mysql
+
+  - job_name: "loki"
+    static_configs:
+      - targets: ["loki:3100"]
+        labels:
+          application: eod
+          component: loki
+
+  - job_name: "alloy"
+    static_configs:
+      - targets: ["alloy:12345"]
+        labels:
+          application: eod
+          component: alloy
+
+  - job_name: "grafana"
+    static_configs:
+      - targets: ["grafana:3000"]
+        labels:
+          application: eod
+          component: grafana
+
+  - job_name: "blackbox-http"
+    metrics_path: /probe
+    params:
+      module: [http_2xx]
+    static_configs:
+      - targets:
+          - "http://app:8080/healthz"
+        labels:
+          application: eod
+          availability_target: app-internal
+      - targets:
+          - "https://www.jojaemin.com/healthz"
+        labels:
+          application: eod
+          availability_target: prod-public
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: blackbox-exporter:9115

--- a/src/main/java/com/eod/eod/common/config/SecurityConfig.java
+++ b/src/main/java/com/eod/eod/common/config/SecurityConfig.java
@@ -69,6 +69,8 @@ public class SecurityConfig {
                         // Prometheus 수집 엔드포인트는 인증 없이 허용하되,
                         // 운영에서는 전용 management 포트를 호스트에 publish 하지 않고 내부 네트워크에서만 scrape 한다.
                         .requestMatchers("/actuator/prometheus").permitAll()
+                        // 외부 가용성 체크용 liveness 엔드포인트
+                        .requestMatchers("/healthz").permitAll()
                         // Swagger 경로 허용
                         .requestMatchers(
                                 "/swagger-ui/**",

--- a/src/main/java/com/eod/eod/common/event/EodBusinessEvent.java
+++ b/src/main/java/com/eod/eod/common/event/EodBusinessEvent.java
@@ -1,0 +1,4 @@
+package com.eod.eod.common.event;
+
+public record EodBusinessEvent(String domain, String action, String result) {
+}

--- a/src/main/java/com/eod/eod/common/event/EodExternalCallEvent.java
+++ b/src/main/java/com/eod/eod/common/event/EodExternalCallEvent.java
@@ -1,0 +1,6 @@
+package com.eod.eod.common.event;
+
+import java.time.Duration;
+
+public record EodExternalCallEvent(String provider, String operation, String result, Duration duration) {
+}

--- a/src/main/java/com/eod/eod/common/event/EodImageUploadEvent.java
+++ b/src/main/java/com/eod/eod/common/event/EodImageUploadEvent.java
@@ -1,0 +1,6 @@
+package com.eod.eod.common.event;
+
+import java.time.Duration;
+
+public record EodImageUploadEvent(String result, long bytes, Duration duration) {
+}

--- a/src/main/java/com/eod/eod/common/event/EodSchedulerRunEvent.java
+++ b/src/main/java/com/eod/eod/common/event/EodSchedulerRunEvent.java
@@ -1,0 +1,4 @@
+package com.eod.eod.common.event;
+
+public record EodSchedulerRunEvent(String task, String result, int processedItems) {
+}

--- a/src/main/java/com/eod/eod/common/health/HealthzController.java
+++ b/src/main/java/com/eod/eod/common/health/HealthzController.java
@@ -1,0 +1,18 @@
+package com.eod.eod.common.health;
+
+import java.util.Map;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HealthzController {
+
+    @GetMapping("/healthz")
+    public ResponseEntity<Map<String, String>> healthz() {
+        return ResponseEntity.ok(Map.of(
+                "status", "UP",
+                "service", "eod-backend"
+        ));
+    }
+}

--- a/src/main/java/com/eod/eod/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/eod/eod/common/jwt/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package com.eod.eod.common.jwt;
 
+import com.eod.eod.common.metrics.EodMetrics;
 import com.eod.eod.domain.user.infrastructure.UserRepository;
 import com.eod.eod.domain.user.model.User;
 import jakarta.servlet.FilterChain;
@@ -26,6 +27,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final UserRepository userRepository;
+    private final EodMetrics eodMetrics;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
@@ -71,24 +73,28 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     } else {
                         // Access Token이 아닌 경우 (Refresh Token 등)
                         log.warn("Access Token이 아닌 토큰 유형: {}", jwtTokenProvider.getTokenType(token));
+                        eodMetrics.recordBusinessEvent("auth", "jwt_invalid_type", "failure");
                         sendUnauthorizedResponse(response, "Access Token이 필요합니다.");
                         return;
                     }
                 } else {
                     // 토큰이 유효하지 않은 경우 (만료 포함)
                     log.warn("유효하지 않은 JWT 토큰");
+                    eodMetrics.recordBusinessEvent("auth", "jwt_invalid", "failure");
                     sendUnauthorizedResponse(response, "유효하지 않은 토큰입니다.");
                     return;
                 }
             } catch (io.jsonwebtoken.ExpiredJwtException e) {
                 // 토큰 만료 - 401 반환하고 필터 체인 중단
                 log.debug("만료된 JWT 토큰: {}", e.getMessage());
+                eodMetrics.recordBusinessEvent("auth", "jwt_expired", "failure");
                 sendUnauthorizedResponse(response, "토큰이 만료되었습니다.");
                 return;
             }
 
         } catch (Exception e) {
             log.error("JWT 인증 실패: {}", e.getMessage(), e);
+            eodMetrics.recordBusinessEvent("auth", "jwt_authenticate", "failure");
             SecurityContextHolder.clearContext();
             sendUnauthorizedResponse(response, "인증에 실패했습니다.");
             return;

--- a/src/main/java/com/eod/eod/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/eod/eod/common/jwt/JwtAuthenticationFilter.java
@@ -1,6 +1,6 @@
 package com.eod.eod.common.jwt;
 
-import com.eod.eod.common.metrics.EodMetrics;
+import com.eod.eod.common.event.EodBusinessEvent;
 import com.eod.eod.domain.user.infrastructure.UserRepository;
 import com.eod.eod.domain.user.model.User;
 import jakarta.servlet.FilterChain;
@@ -9,6 +9,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -27,7 +28,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final UserRepository userRepository;
-    private final EodMetrics eodMetrics;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
@@ -73,28 +74,28 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     } else {
                         // Access Token이 아닌 경우 (Refresh Token 등)
                         log.warn("Access Token이 아닌 토큰 유형: {}", jwtTokenProvider.getTokenType(token));
-                        eodMetrics.recordBusinessEvent("auth", "jwt_invalid_type", "failure");
+                        eventPublisher.publishEvent(new EodBusinessEvent("auth", "jwt_invalid_type", "failure"));
                         sendUnauthorizedResponse(response, "Access Token이 필요합니다.");
                         return;
                     }
                 } else {
                     // 토큰이 유효하지 않은 경우 (만료 포함)
                     log.warn("유효하지 않은 JWT 토큰");
-                    eodMetrics.recordBusinessEvent("auth", "jwt_invalid", "failure");
+                    eventPublisher.publishEvent(new EodBusinessEvent("auth", "jwt_invalid", "failure"));
                     sendUnauthorizedResponse(response, "유효하지 않은 토큰입니다.");
                     return;
                 }
             } catch (io.jsonwebtoken.ExpiredJwtException e) {
                 // 토큰 만료 - 401 반환하고 필터 체인 중단
                 log.debug("만료된 JWT 토큰: {}", e.getMessage());
-                eodMetrics.recordBusinessEvent("auth", "jwt_expired", "failure");
+                eventPublisher.publishEvent(new EodBusinessEvent("auth", "jwt_expired", "failure"));
                 sendUnauthorizedResponse(response, "토큰이 만료되었습니다.");
                 return;
             }
 
         } catch (Exception e) {
             log.error("JWT 인증 실패: {}", e.getMessage(), e);
-            eodMetrics.recordBusinessEvent("auth", "jwt_authenticate", "failure");
+            eventPublisher.publishEvent(new EodBusinessEvent("auth", "jwt_authenticate", "failure"));
             SecurityContextHolder.clearContext();
             sendUnauthorizedResponse(response, "인증에 실패했습니다.");
             return;

--- a/src/main/java/com/eod/eod/common/metrics/EodDomainMetricsConfig.java
+++ b/src/main/java/com/eod/eod/common/metrics/EodDomainMetricsConfig.java
@@ -1,0 +1,47 @@
+package com.eod.eod.common.metrics;
+
+import com.eod.eod.domain.item.infrastructure.ItemClaimRepository;
+import com.eod.eod.domain.item.infrastructure.ItemRepository;
+import com.eod.eod.domain.item.model.Item;
+import com.eod.eod.domain.item.model.ItemClaim;
+import com.eod.eod.domain.reward.infrastructure.RewardRecordRepository;
+import com.eod.eod.domain.user.model.User;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class EodDomainMetricsConfig {
+
+    public EodDomainMetricsConfig(
+            MeterRegistry meterRegistry,
+            ItemRepository itemRepository,
+            ItemClaimRepository itemClaimRepository,
+            RewardRecordRepository rewardRecordRepository
+    ) {
+        for (Item.ItemStatus status : Item.ItemStatus.values()) {
+            Gauge.builder("eod_items_current", itemRepository,
+                            repository -> repository.countByStatusAndDeletedAtIsNull(status))
+                    .description("Current item count by status")
+                    .tag("status", status.name())
+                    .register(meterRegistry);
+        }
+
+        for (ItemClaim.ClaimStatus status : ItemClaim.ClaimStatus.values()) {
+            Gauge.builder("eod_claims_current", itemClaimRepository,
+                            repository -> repository.countByStatusAndItemDeletedAtIsNull(status))
+                    .description("Current item claim count by status")
+                    .tag("status", status.name())
+                    .register(meterRegistry);
+        }
+
+        Gauge.builder("eod_reward_eligible_items", rewardRecordRepository,
+                        repository -> repository.countRewardEligibleItems(Item.ItemStatus.GIVEN, User.Role.USER))
+                .description("Current count of items eligible for reward")
+                .register(meterRegistry);
+
+        Gauge.builder("eod_reward_records_current", rewardRecordRepository, RewardRecordRepository::count)
+                .description("Current reward record count")
+                .register(meterRegistry);
+    }
+}

--- a/src/main/java/com/eod/eod/common/metrics/EodMetrics.java
+++ b/src/main/java/com/eod/eod/common/metrics/EodMetrics.java
@@ -1,0 +1,65 @@
+package com.eod.eod.common.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class EodMetrics {
+
+    private final MeterRegistry meterRegistry;
+
+    public void recordBusinessEvent(String domain, String action, String result) {
+        Counter.builder("eod_business_events_total")
+                .description("EOD domain business events")
+                .tag("domain", domain)
+                .tag("action", action)
+                .tag("result", result)
+                .register(meterRegistry)
+                .increment();
+    }
+
+    public void recordExternalCall(String provider, String operation, String result, Duration duration) {
+        Timer.builder("eod_external_call_seconds")
+                .description("External API call latency")
+                .tag("provider", provider)
+                .tag("operation", operation)
+                .tag("result", result)
+                .register(meterRegistry)
+                .record(duration);
+    }
+
+    public void recordImageUpload(String result, long bytes, Duration duration) {
+        recordBusinessEvent("image", "upload", result);
+        DistributionSummary.builder("eod_image_upload_bytes")
+                .description("Uploaded image size in bytes")
+                .tag("result", result)
+                .baseUnit("bytes")
+                .register(meterRegistry)
+                .record(bytes);
+        Timer.builder("eod_image_upload_seconds")
+                .description("Image upload latency")
+                .tag("result", result)
+                .register(meterRegistry)
+                .record(duration);
+    }
+
+    public void recordSchedulerRun(String task, String result, int processedItems) {
+        Counter.builder("eod_scheduler_runs_total")
+                .description("Scheduled task executions")
+                .tag("task", task)
+                .tag("result", result)
+                .register(meterRegistry)
+                .increment();
+        DistributionSummary.builder("eod_scheduler_processed_items")
+                .description("Items processed by scheduled tasks")
+                .tag("task", task)
+                .register(meterRegistry)
+                .record(processedItems);
+    }
+}

--- a/src/main/java/com/eod/eod/common/metrics/EodMetricsListener.java
+++ b/src/main/java/com/eod/eod/common/metrics/EodMetricsListener.java
@@ -1,0 +1,36 @@
+package com.eod.eod.common.metrics;
+
+import com.eod.eod.common.event.EodBusinessEvent;
+import com.eod.eod.common.event.EodExternalCallEvent;
+import com.eod.eod.common.event.EodImageUploadEvent;
+import com.eod.eod.common.event.EodSchedulerRunEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class EodMetricsListener {
+
+    private final EodMetrics eodMetrics;
+
+    @EventListener
+    public void onBusinessEvent(EodBusinessEvent event) {
+        eodMetrics.recordBusinessEvent(event.domain(), event.action(), event.result());
+    }
+
+    @EventListener
+    public void onExternalCall(EodExternalCallEvent event) {
+        eodMetrics.recordExternalCall(event.provider(), event.operation(), event.result(), event.duration());
+    }
+
+    @EventListener
+    public void onImageUpload(EodImageUploadEvent event) {
+        eodMetrics.recordImageUpload(event.result(), event.bytes(), event.duration());
+    }
+
+    @EventListener
+    public void onSchedulerRun(EodSchedulerRunEvent event) {
+        eodMetrics.recordSchedulerRun(event.task(), event.result(), event.processedItems());
+    }
+}

--- a/src/main/java/com/eod/eod/domain/auth/application/BsmLoginService.java
+++ b/src/main/java/com/eod/eod/domain/auth/application/BsmLoginService.java
@@ -1,5 +1,6 @@
 package com.eod.eod.domain.auth.application;
 
+import com.eod.eod.common.metrics.EodMetrics;
 import com.eod.eod.domain.user.infrastructure.UserRepository;
 import com.eod.eod.domain.user.model.User;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -19,19 +20,26 @@ public class BsmLoginService {
     private final BsmOAuthService bsmOAuthService;
     private final UserRepository userRepository;
     private final AuthService authService;
+    private final EodMetrics eodMetrics;
 
     public LoginResult login(String code) {
-        BsmOAuthService.ExchangeResult exchangeResult = bsmOAuthService.exchangeCode(code, true);
-        JsonNode resource = exchangeResult.resource();
-        if (resource == null || resource.isNull()) {
-            throw new IllegalStateException("BSM resource를 가져오지 못했습니다. (토큰 교환은 성공했을 수 있습니다)");
+        try {
+            BsmOAuthService.ExchangeResult exchangeResult = bsmOAuthService.exchangeCode(code, true);
+            JsonNode resource = exchangeResult.resource();
+            if (resource == null || resource.isNull()) {
+                throw new IllegalStateException("BSM resource를 가져오지 못했습니다. (토큰 교환은 성공했을 수 있습니다)");
+            }
+
+            BsmUserInfo userInfo = BsmUserInfo.from(resource);
+            User user = findOrCreateUser(userInfo);
+
+            AuthService.TokenPair tokenPair = authService.issueTokensForOAuth2Login(user);
+            eodMetrics.recordBusinessEvent("auth", "bsm_login", "success");
+            return new LoginResult(tokenPair.getAccessToken(), tokenPair.getRefreshToken(), user);
+        } catch (RuntimeException e) {
+            eodMetrics.recordBusinessEvent("auth", "bsm_login", "failure");
+            throw e;
         }
-
-        BsmUserInfo userInfo = BsmUserInfo.from(resource);
-        User user = findOrCreateUser(userInfo);
-
-        AuthService.TokenPair tokenPair = authService.issueTokensForOAuth2Login(user);
-        return new LoginResult(tokenPair.getAccessToken(), tokenPair.getRefreshToken(), user);
     }
 
     public User linkDiscordId(User user, String discordId) {

--- a/src/main/java/com/eod/eod/domain/auth/application/BsmLoginService.java
+++ b/src/main/java/com/eod/eod/domain/auth/application/BsmLoginService.java
@@ -23,23 +23,18 @@ public class BsmLoginService {
     private final EodMetrics eodMetrics;
 
     public LoginResult login(String code) {
-        try {
-            BsmOAuthService.ExchangeResult exchangeResult = bsmOAuthService.exchangeCode(code, true);
-            JsonNode resource = exchangeResult.resource();
-            if (resource == null || resource.isNull()) {
-                throw new IllegalStateException("BSM resource를 가져오지 못했습니다. (토큰 교환은 성공했을 수 있습니다)");
-            }
-
-            BsmUserInfo userInfo = BsmUserInfo.from(resource);
-            User user = findOrCreateUser(userInfo);
-
-            AuthService.TokenPair tokenPair = authService.issueTokensForOAuth2Login(user);
-            eodMetrics.recordBusinessEvent("auth", "bsm_login", "success");
-            return new LoginResult(tokenPair.getAccessToken(), tokenPair.getRefreshToken(), user);
-        } catch (RuntimeException e) {
-            eodMetrics.recordBusinessEvent("auth", "bsm_login", "failure");
-            throw e;
+        BsmOAuthService.ExchangeResult exchangeResult = bsmOAuthService.exchangeCode(code, true);
+        JsonNode resource = exchangeResult.resource();
+        if (resource == null || resource.isNull()) {
+            throw new IllegalStateException("BSM resource를 가져오지 못했습니다. (토큰 교환은 성공했을 수 있습니다)");
         }
+
+        BsmUserInfo userInfo = BsmUserInfo.from(resource);
+        User user = findOrCreateUser(userInfo);
+
+        AuthService.TokenPair tokenPair = authService.issueTokensForOAuth2Login(user);
+        eodMetrics.recordBusinessEvent("auth", "bsm_login", "success");
+        return new LoginResult(tokenPair.getAccessToken(), tokenPair.getRefreshToken(), user);
     }
 
     public User linkDiscordId(User user, String discordId) {

--- a/src/main/java/com/eod/eod/domain/auth/application/BsmLoginService.java
+++ b/src/main/java/com/eod/eod/domain/auth/application/BsmLoginService.java
@@ -1,6 +1,7 @@
 package com.eod.eod.domain.auth.application;
 
-import com.eod.eod.common.metrics.EodMetrics;
+import com.eod.eod.common.event.EodBusinessEvent;
+import org.springframework.context.ApplicationEventPublisher;
 import com.eod.eod.domain.user.infrastructure.UserRepository;
 import com.eod.eod.domain.user.model.User;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -20,7 +21,7 @@ public class BsmLoginService {
     private final BsmOAuthService bsmOAuthService;
     private final UserRepository userRepository;
     private final AuthService authService;
-    private final EodMetrics eodMetrics;
+    private final ApplicationEventPublisher eventPublisher;
 
     public LoginResult login(String code) {
         BsmOAuthService.ExchangeResult exchangeResult = bsmOAuthService.exchangeCode(code, true);
@@ -33,7 +34,7 @@ public class BsmLoginService {
         User user = findOrCreateUser(userInfo);
 
         AuthService.TokenPair tokenPair = authService.issueTokensForOAuth2Login(user);
-        eodMetrics.recordBusinessEvent("auth", "bsm_login", "success");
+        eventPublisher.publishEvent(new EodBusinessEvent("auth", "bsm_login", "success"));
         return new LoginResult(tokenPair.getAccessToken(), tokenPair.getRefreshToken(), user);
     }
 

--- a/src/main/java/com/eod/eod/domain/auth/application/BsmOAuthService.java
+++ b/src/main/java/com/eod/eod/domain/auth/application/BsmOAuthService.java
@@ -1,5 +1,6 @@
 package com.eod.eod.domain.auth.application;
 
+import com.eod.eod.common.metrics.EodMetrics;
 import com.fasterxml.jackson.databind.JsonNode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,6 +13,8 @@ import org.springframework.web.client.RestClientResponseException;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -29,6 +32,7 @@ public class BsmOAuthService {
 
     @Qualifier("bsmOauthRestClient")
     private final RestClient bsmOauthRestClient;
+    private final EodMetrics eodMetrics;
 
     @Value("${bsm.auth.client-id}")
     private String clientId;
@@ -77,7 +81,15 @@ public class BsmOAuthService {
     }
 
     private String exchangeCodeForToken(String code) {
-        JsonNode node = requestTokenWithJsonBody(code, true);
+        Instant start = Instant.now();
+        JsonNode node;
+        try {
+            node = requestTokenWithJsonBody(code, true);
+            eodMetrics.recordExternalCall("bsm", "token", "success", Duration.between(start, Instant.now()));
+        } catch (RuntimeException e) {
+            eodMetrics.recordExternalCall("bsm", "token", "failure", Duration.between(start, Instant.now()));
+            throw e;
+        }
 
         String token = extractToken(node);
         if (token == null || token.isBlank()) {
@@ -112,6 +124,7 @@ public class BsmOAuthService {
 
     private Optional<JsonNode> fetchUserResource(String token) {
         log.debug("BSM 사용자 정보 조회 시작");
+        Instant start = Instant.now();
         
         try {
             // BSM 공식 문서: POST /resource with JSON body
@@ -132,10 +145,12 @@ public class BsmOAuthService {
                     .body(JsonNode.class);
                     
             log.info("✅ 사용자 정보 조회 성공");
+            eodMetrics.recordExternalCall("bsm", "resource", "success", Duration.between(start, Instant.now()));
             return Optional.ofNullable(resource);
         } catch (RestClientResponseException e) {
             log.error("❌ 사용자 정보 조회 실패 - {} {}, 응답: {}", 
                     e.getStatusCode(), e.getMessage(), e.getResponseBodyAsString());
+            eodMetrics.recordExternalCall("bsm", "resource", "failure", Duration.between(start, Instant.now()));
             return Optional.empty();
         }
     }

--- a/src/main/java/com/eod/eod/domain/auth/application/BsmOAuthService.java
+++ b/src/main/java/com/eod/eod/domain/auth/application/BsmOAuthService.java
@@ -82,14 +82,8 @@ public class BsmOAuthService {
 
     private String exchangeCodeForToken(String code) {
         Instant start = Instant.now();
-        JsonNode node;
-        try {
-            node = requestTokenWithJsonBody(code, true);
-            eodMetrics.recordExternalCall("bsm", "token", "success", Duration.between(start, Instant.now()));
-        } catch (RuntimeException e) {
-            eodMetrics.recordExternalCall("bsm", "token", "failure", Duration.between(start, Instant.now()));
-            throw e;
-        }
+        JsonNode node = requestTokenWithJsonBody(code, true);
+        eodMetrics.recordExternalCall("bsm", "token", "success", Duration.between(start, Instant.now()));
 
         String token = extractToken(node);
         if (token == null || token.isBlank()) {

--- a/src/main/java/com/eod/eod/domain/auth/application/BsmOAuthService.java
+++ b/src/main/java/com/eod/eod/domain/auth/application/BsmOAuthService.java
@@ -1,11 +1,12 @@
 package com.eod.eod.domain.auth.application;
 
-import com.eod.eod.common.metrics.EodMetrics;
+import com.eod.eod.common.event.EodExternalCallEvent;
 import com.fasterxml.jackson.databind.JsonNode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
@@ -32,7 +33,7 @@ public class BsmOAuthService {
 
     @Qualifier("bsmOauthRestClient")
     private final RestClient bsmOauthRestClient;
-    private final EodMetrics eodMetrics;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Value("${bsm.auth.client-id}")
     private String clientId;
@@ -83,7 +84,7 @@ public class BsmOAuthService {
     private String exchangeCodeForToken(String code) {
         Instant start = Instant.now();
         JsonNode node = requestTokenWithJsonBody(code, true);
-        eodMetrics.recordExternalCall("bsm", "token", "success", Duration.between(start, Instant.now()));
+        eventPublisher.publishEvent(new EodExternalCallEvent("bsm", "token", "success", Duration.between(start, Instant.now())));
 
         String token = extractToken(node);
         if (token == null || token.isBlank()) {
@@ -139,12 +140,12 @@ public class BsmOAuthService {
                     .body(JsonNode.class);
                     
             log.info("✅ 사용자 정보 조회 성공");
-            eodMetrics.recordExternalCall("bsm", "resource", "success", Duration.between(start, Instant.now()));
+            eventPublisher.publishEvent(new EodExternalCallEvent("bsm", "resource", "success", Duration.between(start, Instant.now())));
             return Optional.ofNullable(resource);
         } catch (RestClientResponseException e) {
             log.error("❌ 사용자 정보 조회 실패 - {} {}, 응답: {}", 
                     e.getStatusCode(), e.getMessage(), e.getResponseBodyAsString());
-            eodMetrics.recordExternalCall("bsm", "resource", "failure", Duration.between(start, Instant.now()));
+            eventPublisher.publishEvent(new EodExternalCallEvent("bsm", "resource", "failure", Duration.between(start, Instant.now())));
             return Optional.empty();
         }
     }

--- a/src/main/java/com/eod/eod/domain/image/application/ImageServiceImpl.java
+++ b/src/main/java/com/eod/eod/domain/image/application/ImageServiceImpl.java
@@ -1,6 +1,6 @@
 package com.eod.eod.domain.image.application;
 
-import com.eod.eod.common.metrics.EodMetrics;
+import com.eod.eod.common.event.EodImageUploadEvent;
 import com.eod.eod.domain.image.exception.ImageErrorCode;
 import com.eod.eod.domain.image.exception.ImageException;
 import com.eod.eod.domain.image.infrastructure.ImageRepository;
@@ -10,6 +10,7 @@ import com.eod.eod.domain.user.model.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -41,7 +42,7 @@ public class ImageServiceImpl implements ImageService {
 
     private final ImageRepository imageRepository;
     private final UserFacade userFacade;
-    private final EodMetrics eodMetrics;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Value("${file.upload.dir}")
     private String uploadDir;
@@ -73,7 +74,7 @@ public class ImageServiceImpl implements ImageService {
             throw e;
         }
 
-        eodMetrics.recordImageUpload("success", bytes, Duration.between(start, Instant.now()));
+        eventPublisher.publishEvent(new EodImageUploadEvent("success", bytes, Duration.between(start, Instant.now())));
         return buildImageUrl(storedImage.publicPath());
     }
 

--- a/src/main/java/com/eod/eod/domain/image/application/ImageServiceImpl.java
+++ b/src/main/java/com/eod/eod/domain/image/application/ImageServiceImpl.java
@@ -54,32 +54,27 @@ public class ImageServiceImpl implements ImageService {
     public String uploadImage(MultipartFile file, Long userId) {
         Instant start = Instant.now();
         long bytes = file == null ? 0L : file.getSize();
+        User user = userFacade.getUserById(userId);
+
+        String extension = validateFile(file);
+        StoredImage storedImage = saveFile(file, extension);
+
+        Image image = Image.create(
+            storedImage.publicPath(),
+            file.getOriginalFilename(),
+            file.getSize(),
+            file.getContentType(),
+            user
+        );
         try {
-            User user = userFacade.getUserById(userId);
-
-            String extension = validateFile(file);
-            StoredImage storedImage = saveFile(file, extension);
-
-            Image image = Image.create(
-                storedImage.publicPath(),
-                file.getOriginalFilename(),
-                file.getSize(),
-                file.getContentType(),
-                user
-            );
-            try {
-                imageRepository.save(image);
-            } catch (RuntimeException e) {
-                deleteFileIfExists(storedImage.filePath());
-                throw e;
-            }
-
-            eodMetrics.recordImageUpload("success", bytes, Duration.between(start, Instant.now()));
-            return buildImageUrl(storedImage.publicPath());
+            imageRepository.save(image);
         } catch (RuntimeException e) {
-            eodMetrics.recordImageUpload("failure", bytes, Duration.between(start, Instant.now()));
+            deleteFileIfExists(storedImage.filePath());
             throw e;
         }
+
+        eodMetrics.recordImageUpload("success", bytes, Duration.between(start, Instant.now()));
+        return buildImageUrl(storedImage.publicPath());
     }
 
     private String validateFile(MultipartFile file) {

--- a/src/main/java/com/eod/eod/domain/image/application/ImageServiceImpl.java
+++ b/src/main/java/com/eod/eod/domain/image/application/ImageServiceImpl.java
@@ -1,5 +1,6 @@
 package com.eod.eod.domain.image.application;
 
+import com.eod.eod.common.metrics.EodMetrics;
 import com.eod.eod.domain.image.exception.ImageErrorCode;
 import com.eod.eod.domain.image.exception.ImageException;
 import com.eod.eod.domain.image.infrastructure.ImageRepository;
@@ -23,6 +24,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.time.LocalDate;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Locale;
 import java.util.Set;
 import java.util.UUID;
@@ -38,6 +41,7 @@ public class ImageServiceImpl implements ImageService {
 
     private final ImageRepository imageRepository;
     private final UserFacade userFacade;
+    private final EodMetrics eodMetrics;
 
     @Value("${file.upload.dir}")
     private String uploadDir;
@@ -48,26 +52,34 @@ public class ImageServiceImpl implements ImageService {
     @Override
     @Transactional
     public String uploadImage(MultipartFile file, Long userId) {
-        User user = userFacade.getUserById(userId);
-
-        String extension = validateFile(file);
-        StoredImage storedImage = saveFile(file, extension);
-
-        Image image = Image.create(
-            storedImage.publicPath(),
-            file.getOriginalFilename(),
-            file.getSize(),
-            file.getContentType(),
-            user
-        );
+        Instant start = Instant.now();
+        long bytes = file == null ? 0L : file.getSize();
         try {
-            imageRepository.save(image);
+            User user = userFacade.getUserById(userId);
+
+            String extension = validateFile(file);
+            StoredImage storedImage = saveFile(file, extension);
+
+            Image image = Image.create(
+                storedImage.publicPath(),
+                file.getOriginalFilename(),
+                file.getSize(),
+                file.getContentType(),
+                user
+            );
+            try {
+                imageRepository.save(image);
+            } catch (RuntimeException e) {
+                deleteFileIfExists(storedImage.filePath());
+                throw e;
+            }
+
+            eodMetrics.recordImageUpload("success", bytes, Duration.between(start, Instant.now()));
+            return buildImageUrl(storedImage.publicPath());
         } catch (RuntimeException e) {
-            deleteFileIfExists(storedImage.filePath());
+            eodMetrics.recordImageUpload("failure", bytes, Duration.between(start, Instant.now()));
             throw e;
         }
-
-        return buildImageUrl(storedImage.publicPath());
     }
 
     private String validateFile(MultipartFile file) {

--- a/src/main/java/com/eod/eod/domain/item/application/DisposalReasonService.java
+++ b/src/main/java/com/eod/eod/domain/item/application/DisposalReasonService.java
@@ -27,21 +27,16 @@ public class DisposalReasonService {
      * 폐기 보류 사유 제출
      */
     public DisposalReason submitDisposalReason(Long itemId, String reason, Integer extensionDays, User currentUser) {
-        try {
-            // 물품 조회
-            Item item = itemFacade.getItemById(itemId);
+        // 물품 조회
+        Item item = itemFacade.getItemById(itemId);
 
-            // 폐기 보류 사유 생성 (도메인에서 선생님 권한 및 물품 상태 검증)
-            DisposalReason disposalReason = DisposalReason.create(item, currentUser, reason, extensionDays);
+        // 폐기 보류 사유 생성 (도메인에서 선생님 권한 및 물품 상태 검증)
+        DisposalReason disposalReason = DisposalReason.create(item, currentUser, reason, extensionDays);
 
-            // 저장 및 반환 (영속화된 엔티티 사용)
-            DisposalReason savedReason = disposalReasonRepository.save(disposalReason);
-            eodMetrics.recordBusinessEvent("disposal", "reason_submit", "success");
-            return savedReason;
-        } catch (RuntimeException e) {
-            eodMetrics.recordBusinessEvent("disposal", "reason_submit", "failure");
-            throw e;
-        }
+        // 저장 및 반환 (영속화된 엔티티 사용)
+        DisposalReason savedReason = disposalReasonRepository.save(disposalReason);
+        eodMetrics.recordBusinessEvent("disposal", "reason_submit", "success");
+        return savedReason;
     }
 
     /**
@@ -78,23 +73,18 @@ public class DisposalReasonService {
      */
     @RequireAdmin
     public String extendDisposalPeriod(Long itemId, Long reasonId, User currentUser) {
-        try {
-            // 물품 조회
-            Item item = itemFacade.getItemById(itemId);
+        // 물품 조회
+        Item item = itemFacade.getItemById(itemId);
 
-            // 보류 사유 조회 및 검증
-            DisposalReason disposalReason = disposalReasonRepository.findById(reasonId)
-                    .orElseThrow(() -> new ItemResourceNotFoundException("해당 보류 사유를 찾을 수 없습니다."));
+        // 보류 사유 조회 및 검증
+        DisposalReason disposalReason = disposalReasonRepository.findById(reasonId)
+                .orElseThrow(() -> new ItemResourceNotFoundException("해당 보류 사유를 찾을 수 없습니다."));
 
-            // 폐기 기간 연장 관련 검증과 상태 변경은 도메인에서 처리
-            item.extendDisposalDateWith(disposalReason);
+        // 폐기 기간 연장 관련 검증과 상태 변경은 도메인에서 처리
+        item.extendDisposalDateWith(disposalReason);
 
-            eodMetrics.recordBusinessEvent("disposal", "extend", "success");
-            return item.getDiscardedAt();
-        } catch (RuntimeException e) {
-            eodMetrics.recordBusinessEvent("disposal", "extend", "failure");
-            throw e;
-        }
+        eodMetrics.recordBusinessEvent("disposal", "extend", "success");
+        return item.getDiscardedAt();
     }
 
     public long countItemsToBeDiscarded() {

--- a/src/main/java/com/eod/eod/domain/item/application/DisposalReasonService.java
+++ b/src/main/java/com/eod/eod/domain/item/application/DisposalReasonService.java
@@ -1,7 +1,8 @@
 package com.eod.eod.domain.item.application;
 
 import com.eod.eod.common.annotation.RequireAdmin;
-import com.eod.eod.common.metrics.EodMetrics;
+import com.eod.eod.common.event.EodBusinessEvent;
+import org.springframework.context.ApplicationEventPublisher;
 import com.eod.eod.domain.item.exception.ItemResourceNotFoundException;
 import com.eod.eod.domain.item.infrastructure.DisposalReasonRepository;
 import com.eod.eod.domain.item.model.DisposalReason;
@@ -21,7 +22,7 @@ public class DisposalReasonService {
 
     private final ItemFacade itemFacade;
     private final DisposalReasonRepository disposalReasonRepository;
-    private final EodMetrics eodMetrics;
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * 폐기 보류 사유 제출
@@ -35,7 +36,7 @@ public class DisposalReasonService {
 
         // 저장 및 반환 (영속화된 엔티티 사용)
         DisposalReason savedReason = disposalReasonRepository.save(disposalReason);
-        eodMetrics.recordBusinessEvent("disposal", "reason_submit", "success");
+        eventPublisher.publishEvent(new EodBusinessEvent("disposal", "reason_submit", "success"));
         return savedReason;
     }
 
@@ -83,7 +84,7 @@ public class DisposalReasonService {
         // 폐기 기간 연장 관련 검증과 상태 변경은 도메인에서 처리
         item.extendDisposalDateWith(disposalReason);
 
-        eodMetrics.recordBusinessEvent("disposal", "extend", "success");
+        eventPublisher.publishEvent(new EodBusinessEvent("disposal", "extend", "success"));
         return item.getDiscardedAt();
     }
 

--- a/src/main/java/com/eod/eod/domain/item/application/DisposalReasonService.java
+++ b/src/main/java/com/eod/eod/domain/item/application/DisposalReasonService.java
@@ -1,6 +1,7 @@
 package com.eod.eod.domain.item.application;
 
 import com.eod.eod.common.annotation.RequireAdmin;
+import com.eod.eod.common.metrics.EodMetrics;
 import com.eod.eod.domain.item.exception.ItemResourceNotFoundException;
 import com.eod.eod.domain.item.infrastructure.DisposalReasonRepository;
 import com.eod.eod.domain.item.model.DisposalReason;
@@ -20,19 +21,27 @@ public class DisposalReasonService {
 
     private final ItemFacade itemFacade;
     private final DisposalReasonRepository disposalReasonRepository;
+    private final EodMetrics eodMetrics;
 
     /**
      * 폐기 보류 사유 제출
      */
     public DisposalReason submitDisposalReason(Long itemId, String reason, Integer extensionDays, User currentUser) {
-        // 물품 조회
-        Item item = itemFacade.getItemById(itemId);
+        try {
+            // 물품 조회
+            Item item = itemFacade.getItemById(itemId);
 
-        // 폐기 보류 사유 생성 (도메인에서 선생님 권한 및 물품 상태 검증)
-        DisposalReason disposalReason = DisposalReason.create(item, currentUser, reason, extensionDays);
+            // 폐기 보류 사유 생성 (도메인에서 선생님 권한 및 물품 상태 검증)
+            DisposalReason disposalReason = DisposalReason.create(item, currentUser, reason, extensionDays);
 
-        // 저장 및 반환 (영속화된 엔티티 사용)
-        return disposalReasonRepository.save(disposalReason);
+            // 저장 및 반환 (영속화된 엔티티 사용)
+            DisposalReason savedReason = disposalReasonRepository.save(disposalReason);
+            eodMetrics.recordBusinessEvent("disposal", "reason_submit", "success");
+            return savedReason;
+        } catch (RuntimeException e) {
+            eodMetrics.recordBusinessEvent("disposal", "reason_submit", "failure");
+            throw e;
+        }
     }
 
     /**
@@ -69,17 +78,23 @@ public class DisposalReasonService {
      */
     @RequireAdmin
     public String extendDisposalPeriod(Long itemId, Long reasonId, User currentUser) {
-        // 물품 조회
-        Item item = itemFacade.getItemById(itemId);
+        try {
+            // 물품 조회
+            Item item = itemFacade.getItemById(itemId);
 
-        // 보류 사유 조회 및 검증
-        DisposalReason disposalReason = disposalReasonRepository.findById(reasonId)
-                .orElseThrow(() -> new ItemResourceNotFoundException("해당 보류 사유를 찾을 수 없습니다."));
+            // 보류 사유 조회 및 검증
+            DisposalReason disposalReason = disposalReasonRepository.findById(reasonId)
+                    .orElseThrow(() -> new ItemResourceNotFoundException("해당 보류 사유를 찾을 수 없습니다."));
 
-        // 폐기 기간 연장 관련 검증과 상태 변경은 도메인에서 처리
-        item.extendDisposalDateWith(disposalReason);
+            // 폐기 기간 연장 관련 검증과 상태 변경은 도메인에서 처리
+            item.extendDisposalDateWith(disposalReason);
 
-        return item.getDiscardedAt();
+            eodMetrics.recordBusinessEvent("disposal", "extend", "success");
+            return item.getDiscardedAt();
+        } catch (RuntimeException e) {
+            eodMetrics.recordBusinessEvent("disposal", "extend", "failure");
+            throw e;
+        }
     }
 
     public long countItemsToBeDiscarded() {

--- a/src/main/java/com/eod/eod/domain/item/application/ItemApprovalService.java
+++ b/src/main/java/com/eod/eod/domain/item/application/ItemApprovalService.java
@@ -1,7 +1,8 @@
 package com.eod.eod.domain.item.application;
 
 import com.eod.eod.common.annotation.RequireAdmin;
-import com.eod.eod.common.metrics.EodMetrics;
+import com.eod.eod.common.event.EodBusinessEvent;
+import org.springframework.context.ApplicationEventPublisher;
 import com.eod.eod.domain.item.model.Item;
 import com.eod.eod.domain.item.presentation.dto.response.ItemApprovalResponse;
 import com.eod.eod.domain.user.model.User;
@@ -15,7 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ItemApprovalService {
 
     private final ItemFacade itemFacade;
-    private final EodMetrics eodMetrics;
+    private final ApplicationEventPublisher eventPublisher;
 
     // 물품 승인/거절 처리
     @RequireAdmin
@@ -27,7 +28,7 @@ public class ItemApprovalService {
         // 승인/거절 처리
         item.processApproval(approvalStatus, currentUser);
 
-        eodMetrics.recordBusinessEvent("item", action, "success");
+        eventPublisher.publishEvent(new EodBusinessEvent("item", action, "success"));
         // Response 변환
         return ItemApprovalResponse.from(item);
     }

--- a/src/main/java/com/eod/eod/domain/item/application/ItemApprovalService.java
+++ b/src/main/java/com/eod/eod/domain/item/application/ItemApprovalService.java
@@ -21,19 +21,14 @@ public class ItemApprovalService {
     @RequireAdmin
     public ItemApprovalResponse processApproval(Long itemId, Item.ApprovalStatus approvalStatus, User currentUser) {
         String action = approvalStatus == Item.ApprovalStatus.APPROVED ? "approve" : "reject";
-        try {
-            // 물품 조회
-            Item item = itemFacade.getItemById(itemId);
+        // 물품 조회
+        Item item = itemFacade.getItemById(itemId);
 
-            // 승인/거절 처리
-            item.processApproval(approvalStatus, currentUser);
+        // 승인/거절 처리
+        item.processApproval(approvalStatus, currentUser);
 
-            eodMetrics.recordBusinessEvent("item", action, "success");
-            // Response 변환
-            return ItemApprovalResponse.from(item);
-        } catch (RuntimeException e) {
-            eodMetrics.recordBusinessEvent("item", action, "failure");
-            throw e;
-        }
+        eodMetrics.recordBusinessEvent("item", action, "success");
+        // Response 변환
+        return ItemApprovalResponse.from(item);
     }
 }

--- a/src/main/java/com/eod/eod/domain/item/application/ItemApprovalService.java
+++ b/src/main/java/com/eod/eod/domain/item/application/ItemApprovalService.java
@@ -1,6 +1,7 @@
 package com.eod.eod.domain.item.application;
 
 import com.eod.eod.common.annotation.RequireAdmin;
+import com.eod.eod.common.metrics.EodMetrics;
 import com.eod.eod.domain.item.model.Item;
 import com.eod.eod.domain.item.presentation.dto.response.ItemApprovalResponse;
 import com.eod.eod.domain.user.model.User;
@@ -14,17 +15,25 @@ import org.springframework.transaction.annotation.Transactional;
 public class ItemApprovalService {
 
     private final ItemFacade itemFacade;
+    private final EodMetrics eodMetrics;
 
     // 물품 승인/거절 처리
     @RequireAdmin
     public ItemApprovalResponse processApproval(Long itemId, Item.ApprovalStatus approvalStatus, User currentUser) {
-        // 물품 조회
-        Item item = itemFacade.getItemById(itemId);
+        String action = approvalStatus == Item.ApprovalStatus.APPROVED ? "approve" : "reject";
+        try {
+            // 물품 조회
+            Item item = itemFacade.getItemById(itemId);
 
-        // 승인/거절 처리
-        item.processApproval(approvalStatus, currentUser);
+            // 승인/거절 처리
+            item.processApproval(approvalStatus, currentUser);
 
-        // Response 변환
-        return ItemApprovalResponse.from(item);
+            eodMetrics.recordBusinessEvent("item", action, "success");
+            // Response 변환
+            return ItemApprovalResponse.from(item);
+        } catch (RuntimeException e) {
+            eodMetrics.recordBusinessEvent("item", action, "failure");
+            throw e;
+        }
     }
 }

--- a/src/main/java/com/eod/eod/domain/item/application/ItemClaimService.java
+++ b/src/main/java/com/eod/eod/domain/item/application/ItemClaimService.java
@@ -1,6 +1,7 @@
 package com.eod.eod.domain.item.application;
 
 import com.eod.eod.common.annotation.RequireAdmin;
+import com.eod.eod.common.metrics.EodMetrics;
 import com.eod.eod.domain.item.exception.ItemConflictException;
 import com.eod.eod.domain.item.exception.ItemForbiddenException;
 import com.eod.eod.domain.item.exception.ItemResourceNotFoundException;
@@ -26,29 +27,36 @@ public class ItemClaimService {
     private final ItemFacade itemFacade;
     private final ItemClaimRepository itemClaimRepository;
     private final GiveRecordRepository giveRecordRepository;
+    private final EodMetrics eodMetrics;
 
     public ItemClaimResponse claimItem(Long itemId, LocalDate visitDate, User currentUser) {
-        // 아이템 존재 여부 확인
-        Item item = itemFacade.getItemById(itemId);
+        try {
+            // 아이템 존재 여부 확인
+            Item item = itemFacade.getItemById(itemId);
 
-        // 소유권 주장 가능 여부 검증은 도메인에서 처리
-        item.validateClaimableBy(currentUser);
+            // 소유권 주장 가능 여부 검증은 도메인에서 처리
+            item.validateClaimableBy(currentUser);
 
-        // 중복 주장 확인 (PENDING 상태인 주장이 있는 경우에만 중복으로 간주)
-        if (itemClaimRepository.existsByItemIdAndClaimantIdAndStatus(itemId, currentUser.getId(), ItemClaim.ClaimStatus.PENDING)) {
-            throw new ItemConflictException("이미 해당 분실물에 대해 소유권을 주장하셨습니다.");
+            // 중복 주장 확인 (PENDING 상태인 주장이 있는 경우에만 중복으로 간주)
+            if (itemClaimRepository.existsByItemIdAndClaimantIdAndStatus(itemId, currentUser.getId(), ItemClaim.ClaimStatus.PENDING)) {
+                throw new ItemConflictException("이미 해당 분실물에 대해 소유권을 주장하셨습니다.");
+            }
+
+            // 소유권 주장 생성
+            ItemClaim claim = ItemClaim.builder()
+                    .item(item)
+                    .claimant(currentUser)
+                    .visitDate(visitDate)
+                    .build();
+
+            itemClaimRepository.save(claim);
+
+            eodMetrics.recordBusinessEvent("claim", "create", "success");
+            return ItemClaimResponse.success();
+        } catch (RuntimeException e) {
+            eodMetrics.recordBusinessEvent("claim", "create", "failure");
+            throw e;
         }
-
-        // 소유권 주장 생성
-        ItemClaim claim = ItemClaim.builder()
-                .item(item)
-                .claimant(currentUser)
-                .visitDate(visitDate)
-                .build();
-
-        itemClaimRepository.save(claim);
-
-        return ItemClaimResponse.success();
     }
 
     /**
@@ -57,34 +65,40 @@ public class ItemClaimService {
      */
     @RequireAdmin
     public void approveClaim(Long claimId, User currentUser) {
-        // 소유권 주장 조회
-        ItemClaim claim = itemClaimRepository.findById(claimId)
-                .orElseThrow(() -> new ItemResourceNotFoundException("해당 소유권 주장을 찾을 수 없습니다."));
+        try {
+            // 소유권 주장 조회
+            ItemClaim claim = itemClaimRepository.findById(claimId)
+                    .orElseThrow(() -> new ItemResourceNotFoundException("해당 소유권 주장을 찾을 수 없습니다."));
 
-        // 승인 처리
-        claim.approve();
+            // 승인 처리
+            claim.approve();
 
-        // 물품 승인 처리 (소유권 승인 시 물품도 함께 승인)
-        Item item = claim.getItem();
-        item.processApproval(Item.ApprovalStatus.APPROVED, currentUser);
+            // 물품 승인 처리 (소유권 승인 시 물품도 함께 승인)
+            Item item = claim.getItem();
+            item.processApproval(Item.ApprovalStatus.APPROVED, currentUser);
 
-        // 지급 기록 생성 (수령자: 소유권 주장자, 지급자: 관리자)
-        GiveRecord giveRecord = GiveRecord.builder()
-                .item(item)
-                .giver(currentUser)
-                .receiver(claim.getClaimant())
-                .build();
-        giveRecordRepository.save(giveRecord);
+            // 지급 기록 생성 (수령자: 소유권 주장자, 지급자: 관리자)
+            GiveRecord giveRecord = GiveRecord.builder()
+                    .item(item)
+                    .giver(currentUser)
+                    .receiver(claim.getClaimant())
+                    .build();
+            giveRecordRepository.save(giveRecord);
 
-        // 같은 물품에 대한 다른 PENDING 상태의 주장들을 모두 거절
-        Long itemId = item.getId();
-        List<ItemClaim> otherPendingClaims = itemClaimRepository
-                .findByItemIdAndStatus(itemId, ItemClaim.ClaimStatus.PENDING);
+            // 같은 물품에 대한 다른 PENDING 상태의 주장들을 모두 거절
+            Long itemId = item.getId();
+            List<ItemClaim> otherPendingClaims = itemClaimRepository
+                    .findByItemIdAndStatus(itemId, ItemClaim.ClaimStatus.PENDING);
 
-        for (ItemClaim otherClaim : otherPendingClaims) {
-            if (!otherClaim.getId().equals(claimId)) {
-                otherClaim.reject();
+            for (ItemClaim otherClaim : otherPendingClaims) {
+                if (!otherClaim.getId().equals(claimId)) {
+                    otherClaim.reject();
+                }
             }
+            eodMetrics.recordBusinessEvent("claim", "approve", "success");
+        } catch (RuntimeException e) {
+            eodMetrics.recordBusinessEvent("claim", "approve", "failure");
+            throw e;
         }
     }
 
@@ -93,33 +107,45 @@ public class ItemClaimService {
      */
     @RequireAdmin
     public void rejectClaim(Long claimId, User currentUser) {
-        // 소유권 주장 조회
-        ItemClaim claim = itemClaimRepository.findById(claimId)
-                .orElseThrow(() -> new ItemResourceNotFoundException("해당 소유권 주장을 찾을 수 없습니다."));
+        try {
+            // 소유권 주장 조회
+            ItemClaim claim = itemClaimRepository.findById(claimId)
+                    .orElseThrow(() -> new ItemResourceNotFoundException("해당 소유권 주장을 찾을 수 없습니다."));
 
-        // 거절 처리
-        claim.reject();
+            // 거절 처리
+            claim.reject();
+            eodMetrics.recordBusinessEvent("claim", "reject", "success");
+        } catch (RuntimeException e) {
+            eodMetrics.recordBusinessEvent("claim", "reject", "failure");
+            throw e;
+        }
     }
 
     /**
      * 소유권 주장 취소 (본인만 가능, 관리자 승인 전에만 가능)
      */
     public void cancelClaim(Long claimId, User currentUser) {
-        // 소유권 주장 조회
-        ItemClaim claim = itemClaimRepository.findById(claimId)
-                .orElseThrow(() -> new ItemResourceNotFoundException("해당 소유권 주장을 찾을 수 없습니다."));
+        try {
+            // 소유권 주장 조회
+            ItemClaim claim = itemClaimRepository.findById(claimId)
+                    .orElseThrow(() -> new ItemResourceNotFoundException("해당 소유권 주장을 찾을 수 없습니다."));
 
-        // 본인 확인
-        if (!claim.getClaimant().getId().equals(currentUser.getId())) {
-            throw new ItemForbiddenException("본인의 소유권 주장만 취소할 수 있습니다.");
+            // 본인 확인
+            if (!claim.getClaimant().getId().equals(currentUser.getId())) {
+                throw new ItemForbiddenException("본인의 소유권 주장만 취소할 수 있습니다.");
+            }
+
+            // PENDING 상태인지 확인
+            if (claim.getStatus() != ItemClaim.ClaimStatus.PENDING) {
+                throw new ItemConflictException("대기 중인 소유권 주장만 취소할 수 있습니다.");
+            }
+
+            // 취소 처리 - 레코드 삭제
+            itemClaimRepository.delete(claim);
+            eodMetrics.recordBusinessEvent("claim", "cancel", "success");
+        } catch (RuntimeException e) {
+            eodMetrics.recordBusinessEvent("claim", "cancel", "failure");
+            throw e;
         }
-
-        // PENDING 상태인지 확인
-        if (claim.getStatus() != ItemClaim.ClaimStatus.PENDING) {
-            throw new ItemConflictException("대기 중인 소유권 주장만 취소할 수 있습니다.");
-        }
-
-        // 취소 처리 - 레코드 삭제
-        itemClaimRepository.delete(claim);
     }
 }

--- a/src/main/java/com/eod/eod/domain/item/application/ItemClaimService.java
+++ b/src/main/java/com/eod/eod/domain/item/application/ItemClaimService.java
@@ -1,7 +1,8 @@
 package com.eod.eod.domain.item.application;
 
 import com.eod.eod.common.annotation.RequireAdmin;
-import com.eod.eod.common.metrics.EodMetrics;
+import com.eod.eod.common.event.EodBusinessEvent;
+import org.springframework.context.ApplicationEventPublisher;
 import com.eod.eod.domain.item.exception.ItemConflictException;
 import com.eod.eod.domain.item.exception.ItemForbiddenException;
 import com.eod.eod.domain.item.exception.ItemResourceNotFoundException;
@@ -27,7 +28,7 @@ public class ItemClaimService {
     private final ItemFacade itemFacade;
     private final ItemClaimRepository itemClaimRepository;
     private final GiveRecordRepository giveRecordRepository;
-    private final EodMetrics eodMetrics;
+    private final ApplicationEventPublisher eventPublisher;
 
     public ItemClaimResponse claimItem(Long itemId, LocalDate visitDate, User currentUser) {
         // 아이템 존재 여부 확인
@@ -50,7 +51,7 @@ public class ItemClaimService {
 
         itemClaimRepository.save(claim);
 
-        eodMetrics.recordBusinessEvent("claim", "create", "success");
+        eventPublisher.publishEvent(new EodBusinessEvent("claim", "create", "success"));
         return ItemClaimResponse.success();
     }
 
@@ -89,7 +90,7 @@ public class ItemClaimService {
                 otherClaim.reject();
             }
         }
-        eodMetrics.recordBusinessEvent("claim", "approve", "success");
+        eventPublisher.publishEvent(new EodBusinessEvent("claim", "approve", "success"));
     }
 
     /**
@@ -103,7 +104,7 @@ public class ItemClaimService {
 
         // 거절 처리
         claim.reject();
-        eodMetrics.recordBusinessEvent("claim", "reject", "success");
+        eventPublisher.publishEvent(new EodBusinessEvent("claim", "reject", "success"));
     }
 
     /**
@@ -126,6 +127,6 @@ public class ItemClaimService {
 
         // 취소 처리 - 레코드 삭제
         itemClaimRepository.delete(claim);
-        eodMetrics.recordBusinessEvent("claim", "cancel", "success");
+        eventPublisher.publishEvent(new EodBusinessEvent("claim", "cancel", "success"));
     }
 }

--- a/src/main/java/com/eod/eod/domain/item/application/ItemClaimService.java
+++ b/src/main/java/com/eod/eod/domain/item/application/ItemClaimService.java
@@ -30,33 +30,28 @@ public class ItemClaimService {
     private final EodMetrics eodMetrics;
 
     public ItemClaimResponse claimItem(Long itemId, LocalDate visitDate, User currentUser) {
-        try {
-            // 아이템 존재 여부 확인
-            Item item = itemFacade.getItemById(itemId);
+        // 아이템 존재 여부 확인
+        Item item = itemFacade.getItemById(itemId);
 
-            // 소유권 주장 가능 여부 검증은 도메인에서 처리
-            item.validateClaimableBy(currentUser);
+        // 소유권 주장 가능 여부 검증은 도메인에서 처리
+        item.validateClaimableBy(currentUser);
 
-            // 중복 주장 확인 (PENDING 상태인 주장이 있는 경우에만 중복으로 간주)
-            if (itemClaimRepository.existsByItemIdAndClaimantIdAndStatus(itemId, currentUser.getId(), ItemClaim.ClaimStatus.PENDING)) {
-                throw new ItemConflictException("이미 해당 분실물에 대해 소유권을 주장하셨습니다.");
-            }
-
-            // 소유권 주장 생성
-            ItemClaim claim = ItemClaim.builder()
-                    .item(item)
-                    .claimant(currentUser)
-                    .visitDate(visitDate)
-                    .build();
-
-            itemClaimRepository.save(claim);
-
-            eodMetrics.recordBusinessEvent("claim", "create", "success");
-            return ItemClaimResponse.success();
-        } catch (RuntimeException e) {
-            eodMetrics.recordBusinessEvent("claim", "create", "failure");
-            throw e;
+        // 중복 주장 확인 (PENDING 상태인 주장이 있는 경우에만 중복으로 간주)
+        if (itemClaimRepository.existsByItemIdAndClaimantIdAndStatus(itemId, currentUser.getId(), ItemClaim.ClaimStatus.PENDING)) {
+            throw new ItemConflictException("이미 해당 분실물에 대해 소유권을 주장하셨습니다.");
         }
+
+        // 소유권 주장 생성
+        ItemClaim claim = ItemClaim.builder()
+                .item(item)
+                .claimant(currentUser)
+                .visitDate(visitDate)
+                .build();
+
+        itemClaimRepository.save(claim);
+
+        eodMetrics.recordBusinessEvent("claim", "create", "success");
+        return ItemClaimResponse.success();
     }
 
     /**
@@ -65,41 +60,36 @@ public class ItemClaimService {
      */
     @RequireAdmin
     public void approveClaim(Long claimId, User currentUser) {
-        try {
-            // 소유권 주장 조회
-            ItemClaim claim = itemClaimRepository.findById(claimId)
-                    .orElseThrow(() -> new ItemResourceNotFoundException("해당 소유권 주장을 찾을 수 없습니다."));
+        // 소유권 주장 조회
+        ItemClaim claim = itemClaimRepository.findById(claimId)
+                .orElseThrow(() -> new ItemResourceNotFoundException("해당 소유권 주장을 찾을 수 없습니다."));
 
-            // 승인 처리
-            claim.approve();
+        // 승인 처리
+        claim.approve();
 
-            // 물품 승인 처리 (소유권 승인 시 물품도 함께 승인)
-            Item item = claim.getItem();
-            item.processApproval(Item.ApprovalStatus.APPROVED, currentUser);
+        // 물품 승인 처리 (소유권 승인 시 물품도 함께 승인)
+        Item item = claim.getItem();
+        item.processApproval(Item.ApprovalStatus.APPROVED, currentUser);
 
-            // 지급 기록 생성 (수령자: 소유권 주장자, 지급자: 관리자)
-            GiveRecord giveRecord = GiveRecord.builder()
-                    .item(item)
-                    .giver(currentUser)
-                    .receiver(claim.getClaimant())
-                    .build();
-            giveRecordRepository.save(giveRecord);
+        // 지급 기록 생성 (수령자: 소유권 주장자, 지급자: 관리자)
+        GiveRecord giveRecord = GiveRecord.builder()
+                .item(item)
+                .giver(currentUser)
+                .receiver(claim.getClaimant())
+                .build();
+        giveRecordRepository.save(giveRecord);
 
-            // 같은 물품에 대한 다른 PENDING 상태의 주장들을 모두 거절
-            Long itemId = item.getId();
-            List<ItemClaim> otherPendingClaims = itemClaimRepository
-                    .findByItemIdAndStatus(itemId, ItemClaim.ClaimStatus.PENDING);
+        // 같은 물품에 대한 다른 PENDING 상태의 주장들을 모두 거절
+        Long itemId = item.getId();
+        List<ItemClaim> otherPendingClaims = itemClaimRepository
+                .findByItemIdAndStatus(itemId, ItemClaim.ClaimStatus.PENDING);
 
-            for (ItemClaim otherClaim : otherPendingClaims) {
-                if (!otherClaim.getId().equals(claimId)) {
-                    otherClaim.reject();
-                }
+        for (ItemClaim otherClaim : otherPendingClaims) {
+            if (!otherClaim.getId().equals(claimId)) {
+                otherClaim.reject();
             }
-            eodMetrics.recordBusinessEvent("claim", "approve", "success");
-        } catch (RuntimeException e) {
-            eodMetrics.recordBusinessEvent("claim", "approve", "failure");
-            throw e;
         }
+        eodMetrics.recordBusinessEvent("claim", "approve", "success");
     }
 
     /**
@@ -107,45 +97,35 @@ public class ItemClaimService {
      */
     @RequireAdmin
     public void rejectClaim(Long claimId, User currentUser) {
-        try {
-            // 소유권 주장 조회
-            ItemClaim claim = itemClaimRepository.findById(claimId)
-                    .orElseThrow(() -> new ItemResourceNotFoundException("해당 소유권 주장을 찾을 수 없습니다."));
+        // 소유권 주장 조회
+        ItemClaim claim = itemClaimRepository.findById(claimId)
+                .orElseThrow(() -> new ItemResourceNotFoundException("해당 소유권 주장을 찾을 수 없습니다."));
 
-            // 거절 처리
-            claim.reject();
-            eodMetrics.recordBusinessEvent("claim", "reject", "success");
-        } catch (RuntimeException e) {
-            eodMetrics.recordBusinessEvent("claim", "reject", "failure");
-            throw e;
-        }
+        // 거절 처리
+        claim.reject();
+        eodMetrics.recordBusinessEvent("claim", "reject", "success");
     }
 
     /**
      * 소유권 주장 취소 (본인만 가능, 관리자 승인 전에만 가능)
      */
     public void cancelClaim(Long claimId, User currentUser) {
-        try {
-            // 소유권 주장 조회
-            ItemClaim claim = itemClaimRepository.findById(claimId)
-                    .orElseThrow(() -> new ItemResourceNotFoundException("해당 소유권 주장을 찾을 수 없습니다."));
+        // 소유권 주장 조회
+        ItemClaim claim = itemClaimRepository.findById(claimId)
+                .orElseThrow(() -> new ItemResourceNotFoundException("해당 소유권 주장을 찾을 수 없습니다."));
 
-            // 본인 확인
-            if (!claim.getClaimant().getId().equals(currentUser.getId())) {
-                throw new ItemForbiddenException("본인의 소유권 주장만 취소할 수 있습니다.");
-            }
-
-            // PENDING 상태인지 확인
-            if (claim.getStatus() != ItemClaim.ClaimStatus.PENDING) {
-                throw new ItemConflictException("대기 중인 소유권 주장만 취소할 수 있습니다.");
-            }
-
-            // 취소 처리 - 레코드 삭제
-            itemClaimRepository.delete(claim);
-            eodMetrics.recordBusinessEvent("claim", "cancel", "success");
-        } catch (RuntimeException e) {
-            eodMetrics.recordBusinessEvent("claim", "cancel", "failure");
-            throw e;
+        // 본인 확인
+        if (!claim.getClaimant().getId().equals(currentUser.getId())) {
+            throw new ItemForbiddenException("본인의 소유권 주장만 취소할 수 있습니다.");
         }
+
+        // PENDING 상태인지 확인
+        if (claim.getStatus() != ItemClaim.ClaimStatus.PENDING) {
+            throw new ItemConflictException("대기 중인 소유권 주장만 취소할 수 있습니다.");
+        }
+
+        // 취소 처리 - 레코드 삭제
+        itemClaimRepository.delete(claim);
+        eodMetrics.recordBusinessEvent("claim", "cancel", "success");
     }
 }

--- a/src/main/java/com/eod/eod/domain/item/application/ItemDeleteService.java
+++ b/src/main/java/com/eod/eod/domain/item/application/ItemDeleteService.java
@@ -18,16 +18,11 @@ public class ItemDeleteService {
 
     @RequireAdmin
     public void deleteItem(Long itemId, User currentUser) {
-        try {
-            // 물품 존재 여부 확인
-            Item item = itemFacade.getItemById(itemId);
+        // 물품 존재 여부 확인
+        Item item = itemFacade.getItemById(itemId);
 
-            // 물품 논리 삭제
-            item.softDelete();
-            eodMetrics.recordBusinessEvent("item", "delete", "success");
-        } catch (RuntimeException e) {
-            eodMetrics.recordBusinessEvent("item", "delete", "failure");
-            throw e;
-        }
+        // 물품 논리 삭제
+        item.softDelete();
+        eodMetrics.recordBusinessEvent("item", "delete", "success");
     }
 }

--- a/src/main/java/com/eod/eod/domain/item/application/ItemDeleteService.java
+++ b/src/main/java/com/eod/eod/domain/item/application/ItemDeleteService.java
@@ -1,7 +1,8 @@
 package com.eod.eod.domain.item.application;
 
 import com.eod.eod.common.annotation.RequireAdmin;
-import com.eod.eod.common.metrics.EodMetrics;
+import com.eod.eod.common.event.EodBusinessEvent;
+import org.springframework.context.ApplicationEventPublisher;
 import com.eod.eod.domain.item.model.Item;
 import com.eod.eod.domain.user.model.User;
 import lombok.RequiredArgsConstructor;
@@ -14,7 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ItemDeleteService {
 
     private final ItemFacade itemFacade;
-    private final EodMetrics eodMetrics;
+    private final ApplicationEventPublisher eventPublisher;
 
     @RequireAdmin
     public void deleteItem(Long itemId, User currentUser) {
@@ -23,6 +24,6 @@ public class ItemDeleteService {
 
         // 물품 논리 삭제
         item.softDelete();
-        eodMetrics.recordBusinessEvent("item", "delete", "success");
+        eventPublisher.publishEvent(new EodBusinessEvent("item", "delete", "success"));
     }
 }

--- a/src/main/java/com/eod/eod/domain/item/application/ItemDeleteService.java
+++ b/src/main/java/com/eod/eod/domain/item/application/ItemDeleteService.java
@@ -1,6 +1,7 @@
 package com.eod.eod.domain.item.application;
 
 import com.eod.eod.common.annotation.RequireAdmin;
+import com.eod.eod.common.metrics.EodMetrics;
 import com.eod.eod.domain.item.model.Item;
 import com.eod.eod.domain.user.model.User;
 import lombok.RequiredArgsConstructor;
@@ -13,13 +14,20 @@ import org.springframework.transaction.annotation.Transactional;
 public class ItemDeleteService {
 
     private final ItemFacade itemFacade;
+    private final EodMetrics eodMetrics;
 
     @RequireAdmin
     public void deleteItem(Long itemId, User currentUser) {
-        // 물품 존재 여부 확인
-        Item item = itemFacade.getItemById(itemId);
+        try {
+            // 물품 존재 여부 확인
+            Item item = itemFacade.getItemById(itemId);
 
-        // 물품 논리 삭제
-        item.softDelete();
+            // 물품 논리 삭제
+            item.softDelete();
+            eodMetrics.recordBusinessEvent("item", "delete", "success");
+        } catch (RuntimeException e) {
+            eodMetrics.recordBusinessEvent("item", "delete", "failure");
+            throw e;
+        }
     }
 }

--- a/src/main/java/com/eod/eod/domain/item/application/ItemGiveService.java
+++ b/src/main/java/com/eod/eod/domain/item/application/ItemGiveService.java
@@ -1,7 +1,8 @@
 package com.eod.eod.domain.item.application;
 
 import com.eod.eod.common.annotation.RequireAdmin;
-import com.eod.eod.common.metrics.EodMetrics;
+import com.eod.eod.common.event.EodBusinessEvent;
+import org.springframework.context.ApplicationEventPublisher;
 import com.eod.eod.domain.item.exception.ItemResourceNotFoundException;
 import com.eod.eod.domain.item.infrastructure.GiveRecordRepository;
 import com.eod.eod.domain.item.model.GiveRecord;
@@ -20,7 +21,7 @@ public class ItemGiveService {
     private final ItemFacade itemFacade;
     private final UserRepository userRepository;
     private final GiveRecordRepository giveRecordRepository;
-    private final EodMetrics eodMetrics;
+    private final ApplicationEventPublisher eventPublisher;
 
     // 물품 지급 처리
     @RequireAdmin
@@ -43,6 +44,6 @@ public class ItemGiveService {
                 .build();
 
         giveRecordRepository.save(giveRecord);
-        eodMetrics.recordBusinessEvent("item", "give", "success");
+        eventPublisher.publishEvent(new EodBusinessEvent("item", "give", "success"));
     }
 }

--- a/src/main/java/com/eod/eod/domain/item/application/ItemGiveService.java
+++ b/src/main/java/com/eod/eod/domain/item/application/ItemGiveService.java
@@ -1,6 +1,7 @@
 package com.eod.eod.domain.item.application;
 
 import com.eod.eod.common.annotation.RequireAdmin;
+import com.eod.eod.common.metrics.EodMetrics;
 import com.eod.eod.domain.item.exception.ItemResourceNotFoundException;
 import com.eod.eod.domain.item.infrastructure.GiveRecordRepository;
 import com.eod.eod.domain.item.model.GiveRecord;
@@ -19,27 +20,34 @@ public class ItemGiveService {
     private final ItemFacade itemFacade;
     private final UserRepository userRepository;
     private final GiveRecordRepository giveRecordRepository;
+    private final EodMetrics eodMetrics;
 
     // 물품 지급 처리
     @RequireAdmin
     public void giveItemToStudent(Long itemId, Long receiverId, User currentUser) {
-        // 물품 조회
-        Item item = itemFacade.getItemById(itemId);
+        try {
+            // 물품 조회
+            Item item = itemFacade.getItemById(itemId);
 
-        // 지급받을 학생 확인
-        User receiver = userRepository.findById(receiverId)
-                .orElseThrow(() -> new ItemResourceNotFoundException("해당 학생을 찾을 수 없습니다."));
+            // 지급받을 학생 확인
+            User receiver = userRepository.findById(receiverId)
+                    .orElseThrow(() -> new ItemResourceNotFoundException("해당 학생을 찾을 수 없습니다."));
 
-        // 물품 지급 처리
-        item.giveToStudent(receiver, currentUser);
+            // 물품 지급 처리
+            item.giveToStudent(receiver, currentUser);
 
-        // 지급 기록 생성 (감사 용도)
-        GiveRecord giveRecord = GiveRecord.builder()
-                .item(item)
-                .giver(currentUser)
-                .receiver(receiver)
-                .build();
+            // 지급 기록 생성 (감사 용도)
+            GiveRecord giveRecord = GiveRecord.builder()
+                    .item(item)
+                    .giver(currentUser)
+                    .receiver(receiver)
+                    .build();
 
-        giveRecordRepository.save(giveRecord);
+            giveRecordRepository.save(giveRecord);
+            eodMetrics.recordBusinessEvent("item", "give", "success");
+        } catch (RuntimeException e) {
+            eodMetrics.recordBusinessEvent("item", "give", "failure");
+            throw e;
+        }
     }
 }

--- a/src/main/java/com/eod/eod/domain/item/application/ItemGiveService.java
+++ b/src/main/java/com/eod/eod/domain/item/application/ItemGiveService.java
@@ -25,29 +25,24 @@ public class ItemGiveService {
     // 물품 지급 처리
     @RequireAdmin
     public void giveItemToStudent(Long itemId, Long receiverId, User currentUser) {
-        try {
-            // 물품 조회
-            Item item = itemFacade.getItemById(itemId);
+        // 물품 조회
+        Item item = itemFacade.getItemById(itemId);
 
-            // 지급받을 학생 확인
-            User receiver = userRepository.findById(receiverId)
-                    .orElseThrow(() -> new ItemResourceNotFoundException("해당 학생을 찾을 수 없습니다."));
+        // 지급받을 학생 확인
+        User receiver = userRepository.findById(receiverId)
+                .orElseThrow(() -> new ItemResourceNotFoundException("해당 학생을 찾을 수 없습니다."));
 
-            // 물품 지급 처리
-            item.giveToStudent(receiver, currentUser);
+        // 물품 지급 처리
+        item.giveToStudent(receiver, currentUser);
 
-            // 지급 기록 생성 (감사 용도)
-            GiveRecord giveRecord = GiveRecord.builder()
-                    .item(item)
-                    .giver(currentUser)
-                    .receiver(receiver)
-                    .build();
+        // 지급 기록 생성 (감사 용도)
+        GiveRecord giveRecord = GiveRecord.builder()
+                .item(item)
+                .giver(currentUser)
+                .receiver(receiver)
+                .build();
 
-            giveRecordRepository.save(giveRecord);
-            eodMetrics.recordBusinessEvent("item", "give", "success");
-        } catch (RuntimeException e) {
-            eodMetrics.recordBusinessEvent("item", "give", "failure");
-            throw e;
-        }
+        giveRecordRepository.save(giveRecord);
+        eodMetrics.recordBusinessEvent("item", "give", "success");
     }
 }

--- a/src/main/java/com/eod/eod/domain/item/application/ItemRegistrationService.java
+++ b/src/main/java/com/eod/eod/domain/item/application/ItemRegistrationService.java
@@ -1,6 +1,7 @@
 package com.eod.eod.domain.item.application;
 
 import com.eod.eod.common.annotation.RequireAdmin;
+import com.eod.eod.common.metrics.EodMetrics;
 import com.eod.eod.common.util.DatePrecisionParser;
 import com.eod.eod.common.util.DatePrecisionParser.ParsedDate;
 import com.eod.eod.domain.item.application.command.ItemRegistrationCommand;
@@ -22,26 +23,33 @@ public class ItemRegistrationService {
     private final ItemFacade itemFacade;
     private final PlaceRepository placeRepository;
     private final UserRepository userRepository;
+    private final EodMetrics eodMetrics;
 
     @RequireAdmin
     public Long registerItem(ItemRegistrationCommand command, User currentUser) {
-        ParsedDate parsedDate = validateAndParseFoundAt(command.foundAt(), command.placeId());
-        User student = findStudentByCodeAndName(command.reporterStudentCode(), command.reporterName());
+        try {
+            ParsedDate parsedDate = validateAndParseFoundAt(command.foundAt(), command.placeId());
+            User student = findStudentByCodeAndName(command.reporterStudentCode(), command.reporterName());
 
-        Item item = Item.registerLostItem(
-                currentUser,
-                student,
-                command.placeId(),
-                command.foundPlaceDetail(),
-                command.name(),
-                command.imageUrl(),
-                command.category(),
-                parsedDate.getDateTime(),
-                parsedDate.getPrecision()
-        );
+            Item item = Item.registerLostItem(
+                    currentUser,
+                    student,
+                    command.placeId(),
+                    command.foundPlaceDetail(),
+                    command.name(),
+                    command.imageUrl(),
+                    command.category(),
+                    parsedDate.getDateTime(),
+                    parsedDate.getPrecision()
+            );
 
-        Item savedItem = itemFacade.save(item);
-        return savedItem.getId();
+            Item savedItem = itemFacade.save(item);
+            eodMetrics.recordBusinessEvent("item", "register", "success");
+            return savedItem.getId();
+        } catch (RuntimeException e) {
+            eodMetrics.recordBusinessEvent("item", "register", "failure");
+            throw e;
+        }
     }
 
     /**
@@ -89,20 +97,26 @@ public class ItemRegistrationService {
 
     @RequireAdmin
     public void updateItem(Long itemId, ItemUpdateCommand command, User currentUser) {
-        Item item = itemFacade.getItemById(itemId);
-        ParsedDate parsedDate = validateAndParseFoundAt(command.foundAt(), command.placeId());
-        User student = findStudentByCodeAndName(command.reporterStudentCode(), command.reporterName());
+        try {
+            Item item = itemFacade.getItemById(itemId);
+            ParsedDate parsedDate = validateAndParseFoundAt(command.foundAt(), command.placeId());
+            User student = findStudentByCodeAndName(command.reporterStudentCode(), command.reporterName());
 
-        item.updateItem(
-                currentUser,
-                student,
-                command.placeId(),
-                command.foundPlaceDetail(),
-                command.name(),
-                command.imageUrl(),
-                command.category(),
-                parsedDate.getDateTime(),
-                parsedDate.getPrecision()
-        );
+            item.updateItem(
+                    currentUser,
+                    student,
+                    command.placeId(),
+                    command.foundPlaceDetail(),
+                    command.name(),
+                    command.imageUrl(),
+                    command.category(),
+                    parsedDate.getDateTime(),
+                    parsedDate.getPrecision()
+            );
+            eodMetrics.recordBusinessEvent("item", "update", "success");
+        } catch (RuntimeException e) {
+            eodMetrics.recordBusinessEvent("item", "update", "failure");
+            throw e;
+        }
     }
 }

--- a/src/main/java/com/eod/eod/domain/item/application/ItemRegistrationService.java
+++ b/src/main/java/com/eod/eod/domain/item/application/ItemRegistrationService.java
@@ -1,7 +1,8 @@
 package com.eod.eod.domain.item.application;
 
 import com.eod.eod.common.annotation.RequireAdmin;
-import com.eod.eod.common.metrics.EodMetrics;
+import com.eod.eod.common.event.EodBusinessEvent;
+import org.springframework.context.ApplicationEventPublisher;
 import com.eod.eod.common.util.DatePrecisionParser;
 import com.eod.eod.common.util.DatePrecisionParser.ParsedDate;
 import com.eod.eod.domain.item.application.command.ItemRegistrationCommand;
@@ -23,7 +24,7 @@ public class ItemRegistrationService {
     private final ItemFacade itemFacade;
     private final PlaceRepository placeRepository;
     private final UserRepository userRepository;
-    private final EodMetrics eodMetrics;
+    private final ApplicationEventPublisher eventPublisher;
 
     @RequireAdmin
     public Long registerItem(ItemRegistrationCommand command, User currentUser) {
@@ -43,7 +44,7 @@ public class ItemRegistrationService {
         );
 
         Item savedItem = itemFacade.save(item);
-        eodMetrics.recordBusinessEvent("item", "register", "success");
+        eventPublisher.publishEvent(new EodBusinessEvent("item", "register", "success"));
         return savedItem.getId();
     }
 
@@ -107,6 +108,6 @@ public class ItemRegistrationService {
                 parsedDate.getDateTime(),
                 parsedDate.getPrecision()
         );
-        eodMetrics.recordBusinessEvent("item", "update", "success");
+        eventPublisher.publishEvent(new EodBusinessEvent("item", "update", "success"));
     }
 }

--- a/src/main/java/com/eod/eod/domain/item/application/ItemRegistrationService.java
+++ b/src/main/java/com/eod/eod/domain/item/application/ItemRegistrationService.java
@@ -27,29 +27,24 @@ public class ItemRegistrationService {
 
     @RequireAdmin
     public Long registerItem(ItemRegistrationCommand command, User currentUser) {
-        try {
-            ParsedDate parsedDate = validateAndParseFoundAt(command.foundAt(), command.placeId());
-            User student = findStudentByCodeAndName(command.reporterStudentCode(), command.reporterName());
+        ParsedDate parsedDate = validateAndParseFoundAt(command.foundAt(), command.placeId());
+        User student = findStudentByCodeAndName(command.reporterStudentCode(), command.reporterName());
 
-            Item item = Item.registerLostItem(
-                    currentUser,
-                    student,
-                    command.placeId(),
-                    command.foundPlaceDetail(),
-                    command.name(),
-                    command.imageUrl(),
-                    command.category(),
-                    parsedDate.getDateTime(),
-                    parsedDate.getPrecision()
-            );
+        Item item = Item.registerLostItem(
+                currentUser,
+                student,
+                command.placeId(),
+                command.foundPlaceDetail(),
+                command.name(),
+                command.imageUrl(),
+                command.category(),
+                parsedDate.getDateTime(),
+                parsedDate.getPrecision()
+        );
 
-            Item savedItem = itemFacade.save(item);
-            eodMetrics.recordBusinessEvent("item", "register", "success");
-            return savedItem.getId();
-        } catch (RuntimeException e) {
-            eodMetrics.recordBusinessEvent("item", "register", "failure");
-            throw e;
-        }
+        Item savedItem = itemFacade.save(item);
+        eodMetrics.recordBusinessEvent("item", "register", "success");
+        return savedItem.getId();
     }
 
     /**
@@ -97,26 +92,21 @@ public class ItemRegistrationService {
 
     @RequireAdmin
     public void updateItem(Long itemId, ItemUpdateCommand command, User currentUser) {
-        try {
-            Item item = itemFacade.getItemById(itemId);
-            ParsedDate parsedDate = validateAndParseFoundAt(command.foundAt(), command.placeId());
-            User student = findStudentByCodeAndName(command.reporterStudentCode(), command.reporterName());
+        Item item = itemFacade.getItemById(itemId);
+        ParsedDate parsedDate = validateAndParseFoundAt(command.foundAt(), command.placeId());
+        User student = findStudentByCodeAndName(command.reporterStudentCode(), command.reporterName());
 
-            item.updateItem(
-                    currentUser,
-                    student,
-                    command.placeId(),
-                    command.foundPlaceDetail(),
-                    command.name(),
-                    command.imageUrl(),
-                    command.category(),
-                    parsedDate.getDateTime(),
-                    parsedDate.getPrecision()
-            );
-            eodMetrics.recordBusinessEvent("item", "update", "success");
-        } catch (RuntimeException e) {
-            eodMetrics.recordBusinessEvent("item", "update", "failure");
-            throw e;
-        }
+        item.updateItem(
+                currentUser,
+                student,
+                command.placeId(),
+                command.foundPlaceDetail(),
+                command.name(),
+                command.imageUrl(),
+                command.category(),
+                parsedDate.getDateTime(),
+                parsedDate.getPrecision()
+        );
+        eodMetrics.recordBusinessEvent("item", "update", "success");
     }
 }

--- a/src/main/java/com/eod/eod/domain/item/application/ItemSchedulerService.java
+++ b/src/main/java/com/eod/eod/domain/item/application/ItemSchedulerService.java
@@ -73,13 +73,7 @@ public class ItemSchedulerService {
     ) {
         log.info("{} 스케줄러 시작", taskName);
 
-        List<Item> items;
-        try {
-            items = itemsFetcher.get();
-        } catch (RuntimeException e) {
-            eodMetrics.recordSchedulerRun(metricTaskName, "failure", 0);
-            throw e;
-        }
+        List<Item> items = itemsFetcher.get();
 
         if (items.isEmpty()) {
             log.info("{} 대상 물품이 없습니다.", taskName);

--- a/src/main/java/com/eod/eod/domain/item/application/ItemSchedulerService.java
+++ b/src/main/java/com/eod/eod/domain/item/application/ItemSchedulerService.java
@@ -1,5 +1,6 @@
 package com.eod.eod.domain.item.application;
 
+import com.eod.eod.common.metrics.EodMetrics;
 import com.eod.eod.domain.item.model.Item;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,6 +20,7 @@ import java.util.function.Supplier;
 public class ItemSchedulerService {
 
     private final ItemFacade itemFacade;
+    private final EodMetrics eodMetrics;
 
     // 폐기 유예 기간 (2주)
     private static final int GRACE_PERIOD_WEEKS = 2;
@@ -33,6 +35,7 @@ public class ItemSchedulerService {
 
         processScheduledTask(
                 "폐기 예정 전환",
+                "auto_mark_to_be_discarded",
                 () -> itemFacade.findByStatusAndDiscardedAtBefore(Item.ItemStatus.LOST, twoWeeksLater),
                 Item::markAsToBeDiscarded,
                 item -> String.format("ID: %d, 이름: %s, 등록일: %s, 폐기 예정일: %s",
@@ -50,6 +53,7 @@ public class ItemSchedulerService {
 
         processScheduledTask(
                 "자동 폐기",
+                "auto_discard_expired_items",
                 () -> itemFacade.findByStatusAndDiscardedAtBefore(Item.ItemStatus.TO_BE_DISCARDED, now),
                 Item::discard,
                 item -> String.format("ID: %d, 이름: %s, 폐기 예정일: %s",
@@ -62,16 +66,24 @@ public class ItemSchedulerService {
      */
     private void processScheduledTask(
             String taskName,
+            String metricTaskName,
             Supplier<List<Item>> itemsFetcher,
             Consumer<Item> itemProcessor,
             Function<Item, String> itemInfoProvider
     ) {
         log.info("{} 스케줄러 시작", taskName);
 
-        List<Item> items = itemsFetcher.get();
+        List<Item> items;
+        try {
+            items = itemsFetcher.get();
+        } catch (RuntimeException e) {
+            eodMetrics.recordSchedulerRun(metricTaskName, "failure", 0);
+            throw e;
+        }
 
         if (items.isEmpty()) {
             log.info("{} 대상 물품이 없습니다.", taskName);
+            eodMetrics.recordSchedulerRun(metricTaskName, "success", 0);
             return;
         }
 
@@ -86,6 +98,8 @@ public class ItemSchedulerService {
             }
         }
 
+        String result = processedCount == items.size() ? "success" : "partial_failure";
+        eodMetrics.recordSchedulerRun(metricTaskName, result, processedCount);
         log.info("{} 스케줄러 완료 - 총 {}개 물품 처리", taskName, processedCount);
     }
 }

--- a/src/main/java/com/eod/eod/domain/item/application/ItemSchedulerService.java
+++ b/src/main/java/com/eod/eod/domain/item/application/ItemSchedulerService.java
@@ -1,10 +1,11 @@
 package com.eod.eod.domain.item.application;
 
-import com.eod.eod.common.metrics.EodMetrics;
+import com.eod.eod.common.event.EodSchedulerRunEvent;
 import com.eod.eod.domain.item.model.Item;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,7 +21,7 @@ import java.util.function.Supplier;
 public class ItemSchedulerService {
 
     private final ItemFacade itemFacade;
-    private final EodMetrics eodMetrics;
+    private final ApplicationEventPublisher eventPublisher;
 
     // 폐기 유예 기간 (2주)
     private static final int GRACE_PERIOD_WEEKS = 2;
@@ -77,7 +78,7 @@ public class ItemSchedulerService {
 
         if (items.isEmpty()) {
             log.info("{} 대상 물품이 없습니다.", taskName);
-            eodMetrics.recordSchedulerRun(metricTaskName, "success", 0);
+            eventPublisher.publishEvent(new EodSchedulerRunEvent(metricTaskName, "success", 0));
             return;
         }
 
@@ -93,7 +94,7 @@ public class ItemSchedulerService {
         }
 
         String result = processedCount == items.size() ? "success" : "partial_failure";
-        eodMetrics.recordSchedulerRun(metricTaskName, result, processedCount);
+        eventPublisher.publishEvent(new EodSchedulerRunEvent(metricTaskName, result, processedCount));
         log.info("{} 스케줄러 완료 - 총 {}개 물품 처리", taskName, processedCount);
     }
 }

--- a/src/main/java/com/eod/eod/domain/reward/application/RewardGiveService.java
+++ b/src/main/java/com/eod/eod/domain/reward/application/RewardGiveService.java
@@ -1,5 +1,6 @@
 package com.eod.eod.domain.reward.application;
 
+import com.eod.eod.common.metrics.EodMetrics;
 import com.eod.eod.domain.item.infrastructure.ItemRepository;
 import com.eod.eod.domain.item.model.Item;
 import com.eod.eod.domain.reward.infrastructure.RewardRecordRepository;
@@ -16,31 +17,38 @@ public class RewardGiveService {
 
     private final RewardRecordRepository rewardRecordRepository;
     private final ItemRepository itemRepository;
+    private final EodMetrics eodMetrics;
 
     // 상점 지급 처리
     public void giveRewardToStudent(Long itemId, User currentUser) {
-        // 물품 존재 여부 확인
-        Item item = itemRepository.findByIdAndDeletedAtIsNull(itemId)
-                .orElseThrow(() -> new IllegalArgumentException("물품을 찾을 수 없습니다."));
+        try {
+            // 물품 존재 여부 확인
+            Item item = itemRepository.findByIdAndDeletedAtIsNull(itemId)
+                    .orElseThrow(() -> new IllegalArgumentException("물품을 찾을 수 없습니다."));
 
-        // 습득 신고자(item.student)를 상점 수령인으로 사용
-        User student = item.getStudent();
-        if (student == null) {
-            throw new IllegalStateException("습득 신고자가 없는 물품입니다.");
+            // 습득 신고자(item.student)를 상점 수령인으로 사용
+            User student = item.getStudent();
+            if (student == null) {
+                throw new IllegalStateException("습득 신고자가 없는 물품입니다.");
+            }
+
+            // 중복 상점 지급 방지
+            if (rewardRecordRepository.existsByItemId(itemId)) {
+                throw new IllegalStateException("이미 상점이 지급된 물품입니다.");
+            }
+
+            // 상점 지급 기록 생성 (RewardRecord 도메인에서 권한 및 검증 처리)
+            RewardRecord rewardRecord = RewardRecord.builder()
+                    .student(student)
+                    .item(item)
+                    .teacher(currentUser)
+                    .build();
+
+            rewardRecordRepository.save(rewardRecord);
+            eodMetrics.recordBusinessEvent("reward", "give", "success");
+        } catch (RuntimeException e) {
+            eodMetrics.recordBusinessEvent("reward", "give", "failure");
+            throw e;
         }
-
-        // 중복 상점 지급 방지
-        if (rewardRecordRepository.existsByItemId(itemId)) {
-            throw new IllegalStateException("이미 상점이 지급된 물품입니다.");
-        }
-
-        // 상점 지급 기록 생성 (RewardRecord 도메인에서 권한 및 검증 처리)
-        RewardRecord rewardRecord = RewardRecord.builder()
-                .student(student)
-                .item(item)
-                .teacher(currentUser)
-                .build();
-
-        rewardRecordRepository.save(rewardRecord);
     }
 }

--- a/src/main/java/com/eod/eod/domain/reward/application/RewardGiveService.java
+++ b/src/main/java/com/eod/eod/domain/reward/application/RewardGiveService.java
@@ -1,6 +1,7 @@
 package com.eod.eod.domain.reward.application;
 
-import com.eod.eod.common.metrics.EodMetrics;
+import com.eod.eod.common.event.EodBusinessEvent;
+import org.springframework.context.ApplicationEventPublisher;
 import com.eod.eod.domain.item.infrastructure.ItemRepository;
 import com.eod.eod.domain.item.model.Item;
 import com.eod.eod.domain.reward.infrastructure.RewardRecordRepository;
@@ -17,7 +18,7 @@ public class RewardGiveService {
 
     private final RewardRecordRepository rewardRecordRepository;
     private final ItemRepository itemRepository;
-    private final EodMetrics eodMetrics;
+    private final ApplicationEventPublisher eventPublisher;
 
     // 상점 지급 처리
     public void giveRewardToStudent(Long itemId, User currentUser) {
@@ -44,6 +45,6 @@ public class RewardGiveService {
                 .build();
 
         rewardRecordRepository.save(rewardRecord);
-        eodMetrics.recordBusinessEvent("reward", "give", "success");
+        eventPublisher.publishEvent(new EodBusinessEvent("reward", "give", "success"));
     }
 }

--- a/src/main/java/com/eod/eod/domain/reward/application/RewardGiveService.java
+++ b/src/main/java/com/eod/eod/domain/reward/application/RewardGiveService.java
@@ -21,34 +21,29 @@ public class RewardGiveService {
 
     // 상점 지급 처리
     public void giveRewardToStudent(Long itemId, User currentUser) {
-        try {
-            // 물품 존재 여부 확인
-            Item item = itemRepository.findByIdAndDeletedAtIsNull(itemId)
-                    .orElseThrow(() -> new IllegalArgumentException("물품을 찾을 수 없습니다."));
+        // 물품 존재 여부 확인
+        Item item = itemRepository.findByIdAndDeletedAtIsNull(itemId)
+                .orElseThrow(() -> new IllegalArgumentException("물품을 찾을 수 없습니다."));
 
-            // 습득 신고자(item.student)를 상점 수령인으로 사용
-            User student = item.getStudent();
-            if (student == null) {
-                throw new IllegalStateException("습득 신고자가 없는 물품입니다.");
-            }
-
-            // 중복 상점 지급 방지
-            if (rewardRecordRepository.existsByItemId(itemId)) {
-                throw new IllegalStateException("이미 상점이 지급된 물품입니다.");
-            }
-
-            // 상점 지급 기록 생성 (RewardRecord 도메인에서 권한 및 검증 처리)
-            RewardRecord rewardRecord = RewardRecord.builder()
-                    .student(student)
-                    .item(item)
-                    .teacher(currentUser)
-                    .build();
-
-            rewardRecordRepository.save(rewardRecord);
-            eodMetrics.recordBusinessEvent("reward", "give", "success");
-        } catch (RuntimeException e) {
-            eodMetrics.recordBusinessEvent("reward", "give", "failure");
-            throw e;
+        // 습득 신고자(item.student)를 상점 수령인으로 사용
+        User student = item.getStudent();
+        if (student == null) {
+            throw new IllegalStateException("습득 신고자가 없는 물품입니다.");
         }
+
+        // 중복 상점 지급 방지
+        if (rewardRecordRepository.existsByItemId(itemId)) {
+            throw new IllegalStateException("이미 상점이 지급된 물품입니다.");
+        }
+
+        // 상점 지급 기록 생성 (RewardRecord 도메인에서 권한 및 검증 처리)
+        RewardRecord rewardRecord = RewardRecord.builder()
+                .student(student)
+                .item(item)
+                .teacher(currentUser)
+                .build();
+
+        rewardRecordRepository.save(rewardRecord);
+        eodMetrics.recordBusinessEvent("reward", "give", "success");
     }
 }

--- a/src/test/java/com/eod/eod/common/health/HealthzControllerTest.java
+++ b/src/test/java/com/eod/eod/common/health/HealthzControllerTest.java
@@ -1,0 +1,31 @@
+package com.eod.eod.common.health;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class HealthzControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("GET /healthz는 인증 없이 서비스 liveness 정보를 반환한다")
+    void healthzReturnsLivenessStatusWithoutAuthentication() throws Exception {
+        mockMvc.perform(get("/healthz"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("UP"))
+                .andExpect(jsonPath("$.service").value("eod-backend"));
+    }
+}

--- a/src/test/java/com/eod/eod/common/metrics/EodMetricsListenerTest.java
+++ b/src/test/java/com/eod/eod/common/metrics/EodMetricsListenerTest.java
@@ -1,0 +1,61 @@
+package com.eod.eod.common.metrics;
+
+import static org.mockito.Mockito.verify;
+
+import com.eod.eod.common.event.EodBusinessEvent;
+import com.eod.eod.common.event.EodExternalCallEvent;
+import com.eod.eod.common.event.EodImageUploadEvent;
+import com.eod.eod.common.event.EodSchedulerRunEvent;
+import java.time.Duration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class EodMetricsListenerTest {
+
+    @Mock
+    private EodMetrics eodMetrics;
+
+    @InjectMocks
+    private EodMetricsListener listener;
+
+    @Test
+    @DisplayName("비즈니스 이벤트를 메트릭 기록으로 변환한다")
+    void recordsBusinessEvent() {
+        listener.onBusinessEvent(new EodBusinessEvent("item", "register", "success"));
+
+        verify(eodMetrics).recordBusinessEvent("item", "register", "success");
+    }
+
+    @Test
+    @DisplayName("외부 API 이벤트를 메트릭 기록으로 변환한다")
+    void recordsExternalCallEvent() {
+        Duration duration = Duration.ofMillis(120);
+
+        listener.onExternalCall(new EodExternalCallEvent("bsm", "token", "success", duration));
+
+        verify(eodMetrics).recordExternalCall("bsm", "token", "success", duration);
+    }
+
+    @Test
+    @DisplayName("이미지 업로드 이벤트를 메트릭 기록으로 변환한다")
+    void recordsImageUploadEvent() {
+        Duration duration = Duration.ofMillis(250);
+
+        listener.onImageUpload(new EodImageUploadEvent("success", 1024L, duration));
+
+        verify(eodMetrics).recordImageUpload("success", 1024L, duration);
+    }
+
+    @Test
+    @DisplayName("스케줄러 실행 이벤트를 메트릭 기록으로 변환한다")
+    void recordsSchedulerRunEvent() {
+        listener.onSchedulerRun(new EodSchedulerRunEvent("auto_discard_expired_items", "success", 3));
+
+        verify(eodMetrics).recordSchedulerRun("auto_discard_expired_items", "success", 3);
+    }
+}

--- a/src/test/java/com/eod/eod/common/metrics/EodMetricsTest.java
+++ b/src/test/java/com/eod/eod/common/metrics/EodMetricsTest.java
@@ -1,0 +1,70 @@
+package com.eod.eod.common.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class EodMetricsTest {
+
+    private SimpleMeterRegistry meterRegistry;
+    private EodMetrics eodMetrics;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        eodMetrics = new EodMetrics(meterRegistry);
+    }
+
+    @Test
+    @DisplayName("비즈니스 이벤트를 domain/action/result 라벨로 기록한다")
+    void recordBusinessEvent() {
+        eodMetrics.recordBusinessEvent("item", "register", "success");
+
+        double count = meterRegistry.get("eod_business_events_total")
+                .tag("domain", "item")
+                .tag("action", "register")
+                .tag("result", "success")
+                .counter()
+                .count();
+
+        assertThat(count).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("외부 API 호출 지연시간을 provider/operation/result 라벨로 기록한다")
+    void recordExternalCall() {
+        eodMetrics.recordExternalCall("bsm", "token", "success", Duration.ofMillis(120));
+
+        long count = meterRegistry.get("eod_external_call_seconds")
+                .tag("provider", "bsm")
+                .tag("operation", "token")
+                .tag("result", "success")
+                .timer()
+                .count();
+
+        assertThat(count).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("스케줄러 실행 결과와 처리 건수를 기록한다")
+    void recordSchedulerRun() {
+        eodMetrics.recordSchedulerRun("auto_discard_expired_items", "success", 3);
+
+        double eventCount = meterRegistry.get("eod_scheduler_runs_total")
+                .tag("task", "auto_discard_expired_items")
+                .tag("result", "success")
+                .counter()
+                .count();
+        double processedCount = meterRegistry.get("eod_scheduler_processed_items")
+                .tag("task", "auto_discard_expired_items")
+                .summary()
+                .totalAmount();
+
+        assertThat(eventCount).isEqualTo(1.0);
+        assertThat(processedCount).isEqualTo(3.0);
+    }
+}

--- a/src/test/java/com/eod/eod/domain/auth/application/BsmLoginServiceTest.java
+++ b/src/test/java/com/eod/eod/domain/auth/application/BsmLoginServiceTest.java
@@ -1,6 +1,6 @@
 package com.eod.eod.domain.auth.application;
 
-import com.eod.eod.common.metrics.EodMetrics;
+import com.eod.eod.common.event.EodBusinessEvent;
 import com.eod.eod.domain.user.infrastructure.UserRepository;
 import com.eod.eod.domain.user.model.User;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 import java.util.Optional;
 
@@ -36,7 +37,7 @@ class BsmLoginServiceTest {
     private AuthService authService;
 
     @Mock
-    private EodMetrics eodMetrics;
+    private ApplicationEventPublisher eventPublisher;
 
     @InjectMocks
     private BsmLoginService bsmLoginService;
@@ -97,6 +98,7 @@ class BsmLoginServiceTest {
                         user.getIsGraduate() != null &&
                         user.getRole() == User.Role.USER
         ));
+        verify(eventPublisher).publishEvent(new EodBusinessEvent("auth", "bsm_login", "success"));
     }
 
     @Test

--- a/src/test/java/com/eod/eod/domain/auth/application/BsmLoginServiceTest.java
+++ b/src/test/java/com/eod/eod/domain/auth/application/BsmLoginServiceTest.java
@@ -1,5 +1,6 @@
 package com.eod.eod.domain.auth.application;
 
+import com.eod.eod.common.metrics.EodMetrics;
 import com.eod.eod.domain.user.infrastructure.UserRepository;
 import com.eod.eod.domain.user.model.User;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -33,6 +34,9 @@ class BsmLoginServiceTest {
 
     @Mock
     private AuthService authService;
+
+    @Mock
+    private EodMetrics eodMetrics;
 
     @InjectMocks
     private BsmLoginService bsmLoginService;


### PR DESCRIPTION
## 📋 요약
Grafana Logs Drilldown으로 백엔드 애플리케이션 로그를 확인할 수 있도록 Loki와 Grafana Alloy 기반 로그 수집 스택을 추가했습니다.

## 🔗 관련 이슈
close #271

## 🔄 변경 사항
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 문서 업데이트
- [ ] 스타일 변경
- [ ] 리팩토링
- [ ] 성능 개선
- [ ] 테스트 추가

### 변경된 내용
- dev/prod Docker Compose에 Loki와 Alloy 서비스를 추가했습니다.
- Grafana를 `12.4.0`으로 업그레이드하고 Loki datasource를 provisioning에 추가했습니다.
- Alloy가 Spring Boot 파일 로그를 읽어 Loki로 전송하도록 `monitoring/alloy/config.alloy`를 추가했습니다.
- Loki Drilldown 지원을 위해 `volume_enabled`와 `discover_service_name` 설정을 추가했습니다.
- 운영 환경에서는 `server="eod-prod-01"`, `env="prod"` 라벨을 compose에 고정했습니다.
- dev 환경에서는 Loki API를 `127.0.0.1:3100`에만 노출해 로컬 점검이 가능하게 했고, prod 환경에서는 Loki 포트를 외부에 공개하지 않았습니다.

### 변경 이유
기존 Grafana/Prometheus 구성은 메트릭 확인은 가능하지만 실제 애플리케이션 로그를 Grafana에서 서버/환경/레벨 기준으로 드릴다운할 수 없었습니다. Loki를 로그 저장소로 추가하고 Alloy로 기존 `application.log`를 수집해 Grafana에서 장애 시점의 로그를 바로 확인할 수 있도록 했습니다.

## ✅ 체크리스트
- [ ] 코드 리뷰 완료
- [x] 테스트 통과
- [x] 문서 업데이트 (필요한 경우)
- [x] 브레이킹 체인지 확인

## 검증
- [x] YAML parse 확인
- [x] `docker compose -f docker-compose.yml config` 통과
- [x] `docker compose -f docker-compose.prod.yml config` 통과
- [x] `./gradlew test` 통과

## 참고
현재 로컬 Docker daemon이 꺼져 있어 실제 컨테이너 기동 검증은 수행하지 못했습니다. compose 렌더링과 애플리케이션 테스트는 통과했습니다.