### PR TITLE
fix: Grafana Drilldown 로그 미표시 문제 수정

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -3,7 +3,7 @@ services:
     image: ghcr.io/${GITHUB_REPOSITORY:-bssmeod/eodiback}:latest
     container_name: eod-app
     volumes:
-      - /eod/prod/logs:/logs
+      - app-logs-prod:/logs
       - /eod/uploads:/eod/uploads
     restart: always
     ports:
@@ -157,7 +157,7 @@ services:
       - APP_CONTAINER_NAME=eod-app
     volumes:
       - ./monitoring/alloy/config.alloy:/etc/alloy/config.alloy:ro
-      - /eod/prod/logs:/var/log/eod:ro
+      - app-logs-prod:/var/log/eod:ro
       - alloy-data-prod:/var/lib/alloy
     depends_on:
       loki:
@@ -191,6 +191,8 @@ volumes:
   mysql-data-prod:
     external: true
     name: eod_mysql-data-prod
+  app-logs-prod:
+    name: eod_app-logs-prod
   loki-data-prod:
     name: eod_loki-data-prod
   alloy-data-prod:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     image: ghcr.io/${GITHUB_REPOSITORY:-bssmeod/eodiback}:latest
     container_name: eod-app-dev
     volumes:
-      - /eod/logs:/logs
+      - app-logs-dev:/logs
       - /eod/uploads:/eod/uploads
     restart: always
     ports:
@@ -146,7 +146,7 @@ services:
       - APP_CONTAINER_NAME=eod-app-dev
     volumes:
       - ./monitoring/alloy/config.alloy:/etc/alloy/config.alloy:ro
-      - /eod/logs:/var/log/eod:ro
+      - app-logs-dev:/var/log/eod:ro
       - alloy-data-dev:/var/lib/alloy
     depends_on:
       loki:
@@ -180,6 +180,8 @@ volumes:
   mysql-data-dev:
     external: true
     name: eod_mysql-data-dev
+  app-logs-dev:
+    name: eod_app-logs-dev
   loki-data-dev:
     name: eod_loki-data-dev
   alloy-data-dev:

--- a/monitoring/alloy/config.alloy
+++ b/monitoring/alloy/config.alloy
@@ -19,6 +19,11 @@ loki.process "eod_app" {
     expression = "^(?P<timestamp>\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d{3}) (?P<level>[A-Z]+)\\s+\\[(?P<thread>[^\\]]+)\\] (?P<logger>[^ ]+) - (?P<message>.*)$"
   }
 
+  stage.timestamp {
+    source = "timestamp"
+    format = "2006-01-02 15:04:05.000"
+  }
+
   stage.labels {
     values = {
       level = "",


### PR DESCRIPTION
## Summary
- 로그 볼륨을 bind mount에서 named volume으로 교체 (dev/prod 동일)
- `spring` 유저가 `ubuntu` 소유 bind mount 디렉토리에 쓰기 권한 없어 `application.log` 생성 실패 → Alloy가 읽을 파일 없음 → Loki에 데이터 없음 → Grafana Drilldown 빈 화면
- `app`과 `alloy`가 동일 named volume 공유하여 권한 문제 해소
- Alloy `stage.timestamp` 추가: 로그 실제 시각으로 Loki에 저장

## Test plan
- [ ] `docker compose up -d` 후 `docker exec eod-alloy-dev ls /var/log/eod/` 에서 `application.log` 확인
- [ ] Grafana Drilldown Logs에서 `eod-backend` 서비스 로그 표시 확인