### PR TITLE
feat: Grafana 대시보드 가용성 패널 및 한국어 설명 추가

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -15,7 +15,7 @@ services:
       - JWT_SECRET=${JWT_SECRET}
       - BASE_URL=${BASE_URL}
       - FRONTEND_BASE_URL=${FRONTEND_BASE_URL}
-      - LOG_DIR=${LOG_DIR:-/logs}
+      - LOG_DIR=/logs
       - BSM_CLIENT_ID=${BSM_CLIENT_ID}
       - BSM_CLIENT_SECRET=${BSM_CLIENT_SECRET}
       - BSM_OAUTH_BASE_URL=${BSM_OAUTH_BASE_URL}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - JWT_SECRET=${JWT_SECRET}
       - BASE_URL=${BASE_URL}
       - FRONTEND_BASE_URL=${FRONTEND_BASE_URL}
-      - LOG_DIR=${LOG_DIR:-/logs}
+      - LOG_DIR=/logs
       - BSM_CLIENT_ID=${BSM_CLIENT_ID}
       - BSM_CLIENT_SECRET=${BSM_CLIENT_SECRET}
       - BSM_OAUTH_BASE_URL=${BSM_OAUTH_BASE_URL}

--- a/monitoring/grafana/dashboards/eod-domain-metrics.json
+++ b/monitoring/grafana/dashboards/eod-domain-metrics.json
@@ -84,7 +84,8 @@
         }
       ],
       "title": "Business Events",
-      "type": "timeseries"
+      "type": "timeseries",
+      "description": "\ub3c4\uba54\uc778\ubcc4 \ube44\uc988\ub2c8\uc2a4 \uc774\ubca4\ud2b8 \ubc1c\uc0dd \uac74\uc218 (5\ubd84 \ub204\uc801)"
     },
     {
       "datasource": {
@@ -158,7 +159,8 @@
         }
       ],
       "title": "Business Failures",
-      "type": "timeseries"
+      "type": "timeseries",
+      "description": "\ucc98\ub9ac \uc2e4\ud328\ud55c \ube44\uc988\ub2c8\uc2a4 \uc774\ubca4\ud2b8 \uac74\uc218 (10\ubd84 \ub204\uc801)"
     },
     {
       "datasource": {
@@ -227,7 +229,8 @@
         }
       ],
       "title": "Items by Status",
-      "type": "bargauge"
+      "type": "bargauge",
+      "description": "\ubb3c\uac74(Item) \uc0c1\ud0dc\ubcc4 \ud604\uc7ac \uc218\ub7c9"
     },
     {
       "datasource": {
@@ -296,7 +299,8 @@
         }
       ],
       "title": "Claims by Status",
-      "type": "bargauge"
+      "type": "bargauge",
+      "description": "\uc694\uccad(Claim) \uc0c1\ud0dc\ubcc4 \ud604\uc7ac \uc218\ub7c9"
     },
     {
       "datasource": {
@@ -369,7 +373,8 @@
         }
       ],
       "title": "Rewards",
-      "type": "stat"
+      "type": "stat",
+      "description": "\ub9ac\uc6cc\ub4dc \ub300\uc0c1 \ubb3c\uac74 \uc218 / \ub204\uc801 \ub9ac\uc6cc\ub4dc \uc9c0\uae09 \uac74\uc218"
     },
     {
       "datasource": {
@@ -436,7 +441,8 @@
         }
       ],
       "title": "BSM External Call P95",
-      "type": "timeseries"
+      "type": "timeseries",
+      "description": "BSM \uc678\ubd80 API P95 \uc751\ub2f5 \uc2dc\uac04 \u2014 operation \u00b7 result\ubcc4"
     },
     {
       "datasource": {
@@ -502,7 +508,8 @@
         }
       ],
       "title": "Image Uploads",
-      "type": "timeseries"
+      "type": "timeseries",
+      "description": "\uc774\ubbf8\uc9c0 \uc5c5\ub85c\ub4dc \uc131\uacf5/\uc2e4\ud328 \uac74\uc218 (5\ubd84 \ub204\uc801)"
     },
     {
       "datasource": {
@@ -579,7 +586,8 @@
         }
       ],
       "title": "Schedulers",
-      "type": "timeseries"
+      "type": "timeseries",
+      "description": "\uc2a4\ucf00\uc904\ub7ec \uc2e4\ud589 \ud69f\uc218 \ubc0f \ucc98\ub9ac \uac74\uc218 (1\uc2dc\uac04 \ub204\uc801)"
     }
   ],
   "preload": false,

--- a/monitoring/grafana/dashboards/eod-infrastructure.json
+++ b/monitoring/grafana/dashboards/eod-infrastructure.json
@@ -84,7 +84,8 @@
         }
       ],
       "title": "HTTP Availability",
-      "type": "stat"
+      "type": "stat",
+      "description": "\ud5ec\uc2a4\uccb4\ud06c \uc5d4\ub4dc\ud3ec\uc778\ud2b8 \ud604\uc7ac UP/DOWN \uc0c1\ud0dc"
     },
     {
       "datasource": {
@@ -319,7 +320,8 @@
         }
       ],
       "title": "Probe Availability (\uc678\ubd80)",
-      "type": "stat"
+      "type": "stat",
+      "description": "\uc678\ubd80\uc5d0\uc11c \ud5ec\uc2a4\uccb4\ud06c probe \uc131\uacf5\ub960 \u2014 24h \u00b7 7d \u00b7 30d \uae30\uc900"
     },
     {
       "datasource": {
@@ -414,7 +416,8 @@
         }
       ],
       "title": "HTTP Success Rate",
-      "type": "stat"
+      "type": "stat",
+      "description": "5xx \uc5d0\ub7ec\ub97c \uc81c\uc678\ud55c HTTP \uc694\uccad \uc131\uacf5\ub960 \u2014 24h \u00b7 7d \u00b7 30d \uae30\uc900"
     },
     {
       "datasource": {
@@ -691,7 +694,8 @@
         }
       ],
       "title": "MySQL Connection Usage",
-      "type": "stat"
+      "type": "stat",
+      "description": "MySQL \ucd5c\ub300 \ud5c8\uc6a9 \ucee4\ub125\uc158 \ub300\ube44 \ud604\uc7ac \uc0ac\uc6a9\ub960"
     },
     {
       "datasource": {
@@ -756,7 +760,8 @@
         }
       ],
       "title": "Monitoring Targets",
-      "type": "stat"
+      "type": "stat",
+      "description": "Prometheus\uac00 \uc218\uc9d1 \uc911\uc778 \uac01 \uc11c\ube44\uc2a4\uc758 \ud65c\uc131 \uc0c1\ud0dc"
     }
   ],
   "preload": false,

--- a/monitoring/grafana/dashboards/eod-infrastructure.json
+++ b/monitoring/grafana/dashboards/eod-infrastructure.json
@@ -233,6 +233,196 @@
       },
       "fieldConfig": {
         "defaults": {
+          "decimals": 2,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 99
+              },
+              {
+                "color": "green",
+                "value": 99.9
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 5
+      },
+      "id": 9,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "avg_over_time(probe_success{job=\"blackbox-http\", availability_target=\"prod-public\"}[1d]) * 100",
+          "legendFormat": "24h",
+          "instant": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "avg_over_time(probe_success{job=\"blackbox-http\", availability_target=\"prod-public\"}[7d]) * 100",
+          "legendFormat": "7d",
+          "instant": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "avg_over_time(probe_success{job=\"blackbox-http\", availability_target=\"prod-public\"}[30d]) * 100",
+          "legendFormat": "30d",
+          "instant": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Probe Availability (\uc678\ubd80)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 2,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 99
+              },
+              {
+                "color": "green",
+                "value": 99.9
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 5
+      },
+      "id": 10,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "(1 - sum(rate(http_server_requests_seconds_count{application=\"eod\", status=~\"5..\"}[1d])) / sum(rate(http_server_requests_seconds_count{application=\"eod\", uri!=\"UNKNOWN\"}[1d]))) * 100",
+          "legendFormat": "24h",
+          "instant": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "(1 - sum(rate(http_server_requests_seconds_count{application=\"eod\", status=~\"5..\"}[7d])) / sum(rate(http_server_requests_seconds_count{application=\"eod\", uri!=\"UNKNOWN\"}[7d]))) * 100",
+          "legendFormat": "7d",
+          "instant": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "(1 - sum(rate(http_server_requests_seconds_count{application=\"eod\", status=~\"5..\"}[30d])) / sum(rate(http_server_requests_seconds_count{application=\"eod\", uri!=\"UNKNOWN\"}[30d]))) * 100",
+          "legendFormat": "30d",
+          "instant": true,
+          "refId": "C"
+        }
+      ],
+      "title": "HTTP Success Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
           "custom": {
             "drawStyle": "line",
             "fillOpacity": 8,
@@ -267,7 +457,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 5
+        "y": 11
       },
       "id": 4,
       "options": {
@@ -333,7 +523,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 5
+        "y": 11
       },
       "id": 5,
       "options": {
@@ -396,7 +586,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 13
+        "y": 19
       },
       "id": 6,
       "options": {
@@ -466,7 +656,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 13
+        "y": 19
       },
       "id": 7,
       "options": {
@@ -531,7 +721,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 13
+        "y": 19
       },
       "id": 8,
       "options": {

--- a/monitoring/grafana/dashboards/eod-overview.json
+++ b/monitoring/grafana/dashboards/eod-overview.json
@@ -113,7 +113,8 @@
         }
       ],
       "title": "HTTP P95 Latency",
-      "type": "timeseries"
+      "type": "timeseries",
+      "description": "\uc804\uccb4 \uc694\uccad \uc911 \uac00\uc7a5 \ub290\ub9b0 5%\uc758 \uc751\ub2f5 \uc2dc\uac04"
     },
     {
       "datasource": {
@@ -160,7 +161,8 @@
         }
       ],
       "title": "HTTP Responses by Status",
-      "type": "timeseries"
+      "type": "timeseries",
+      "description": "HTTP \uc0c1\ud0dc \ucf54\ub4dc\ubcc4 \ucd08\ub2f9 \uc694\uccad \uc218"
     },
     {
       "datasource": {
@@ -216,7 +218,8 @@
         }
       ],
       "title": "HikariCP Connections",
-      "type": "timeseries"
+      "type": "timeseries",
+      "description": "DB \ucee4\ub125\uc158 \ud480 \uc0ac\uc6a9 \ud604\ud669 (\ud65c\uc131 / \uc720\ud734)"
     }
   ],
   "refresh": "10s",


### PR DESCRIPTION
## Summary
- 서비스 가용성 % 패널 2개 추가 (infrastructure 대시보드)
- Probe Availability: 외부 헬스체크 성공률 24h/7d/30d
- HTTP Success Rate: 5xx 제외 요청 성공률 24h/7d/30d
- 임계값 기준: 99.9% 초록 / 99% 노랑 / 미만 빨강
- 3개 대시보드 총 16개 패널에 한국어 설명 추가 (툴팁)

## Test plan
- [ ] Grafana infrastructure 대시보드에서 가용성 패널 2개 확인
- [ ] 패널 ⓘ 아이콘 hover 시 한국어 설명 표시 확인