### PR TITLE
feat: 로그 수집 안정화 및 MySQL 로그 추가

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -34,15 +34,22 @@ services:
     image: mysql:8.0
     container_name: eod-mysql
     restart: always
+    command:
+      - --log-error=/var/log/mysql/error.log
+      - --slow-query-log=ON
+      - --slow-query-log-file=/var/log/mysql/slow.log
+      - --long-query-time=1
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
       MYSQL_DATABASE: ${MYSQL_DATABASE}
       MYSQL_USER: ${MYSQL_USER}
       MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      TZ: Asia/Seoul
     ports:
       - "3307:3306"
     volumes:
       - mysql-data-prod:/var/lib/mysql
+      - mysql-logs-prod:/var/log/mysql
     networks:
       - eod-network
     healthcheck:
@@ -160,6 +167,7 @@ services:
     volumes:
       - ./monitoring/alloy/config.alloy:/etc/alloy/config.alloy:ro
       - app-logs-prod:/var/log/eod:ro
+      - mysql-logs-prod:/var/log/mysql:ro
       - alloy-data-prod:/var/lib/alloy
     depends_on:
       loki:
@@ -195,6 +203,8 @@ volumes:
     name: eod_mysql-data-prod
   app-logs-prod:
     name: eod_app-logs-prod
+  mysql-logs-prod:
+    name: eod_mysql-logs-prod
   loki-data-prod:
     name: eod_loki-data-prod
   alloy-data-prod:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -16,6 +16,7 @@ services:
       - BASE_URL=${BASE_URL}
       - FRONTEND_BASE_URL=${FRONTEND_BASE_URL}
       - LOG_DIR=/logs
+      - TZ=Asia/Seoul
       - BSM_CLIENT_ID=${BSM_CLIENT_ID}
       - BSM_CLIENT_SECRET=${BSM_CLIENT_SECRET}
       - BSM_OAUTH_BASE_URL=${BSM_OAUTH_BASE_URL}
@@ -155,6 +156,7 @@ services:
       - SERVER_NAME=eod-prod-01
       - ENVIRONMENT=prod
       - APP_CONTAINER_NAME=eod-app
+      - TZ=Asia/Seoul
     volumes:
       - ./monitoring/alloy/config.alloy:/etc/alloy/config.alloy:ro
       - app-logs-prod:/var/log/eod:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - BASE_URL=${BASE_URL}
       - FRONTEND_BASE_URL=${FRONTEND_BASE_URL}
       - LOG_DIR=/logs
+      - TZ=Asia/Seoul
       - BSM_CLIENT_ID=${BSM_CLIENT_ID}
       - BSM_CLIENT_SECRET=${BSM_CLIENT_SECRET}
       - BSM_OAUTH_BASE_URL=${BSM_OAUTH_BASE_URL}
@@ -144,6 +145,7 @@ services:
       - SERVER_NAME=${SERVER_NAME:-local-dev}
       - ENVIRONMENT=${ENVIRONMENT:-dev}
       - APP_CONTAINER_NAME=eod-app-dev
+      - TZ=Asia/Seoul
     volumes:
       - ./monitoring/alloy/config.alloy:/etc/alloy/config.alloy:ro
       - app-logs-dev:/var/log/eod:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,15 +35,22 @@ services:
     image: mysql:8.0
     container_name: eod-mysql-dev
     restart: always
+    command:
+      - --log-error=/var/log/mysql/error.log
+      - --slow-query-log=ON
+      - --slow-query-log-file=/var/log/mysql/slow.log
+      - --long-query-time=1
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
       MYSQL_DATABASE: ${MYSQL_DATABASE}
       MYSQL_USER: ${MYSQL_USER}
       MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      TZ: Asia/Seoul
     ports:
       - "3306:3306"
     volumes:
       - mysql-data-dev:/var/lib/mysql
+      - mysql-logs-dev:/var/log/mysql
     networks:
       - eod-network-dev
     healthcheck:
@@ -149,6 +156,7 @@ services:
     volumes:
       - ./monitoring/alloy/config.alloy:/etc/alloy/config.alloy:ro
       - app-logs-dev:/var/log/eod:ro
+      - mysql-logs-dev:/var/log/mysql:ro
       - alloy-data-dev:/var/lib/alloy
     depends_on:
       loki:
@@ -184,6 +192,8 @@ volumes:
     name: eod_mysql-data-dev
   app-logs-dev:
     name: eod_app-logs-dev
+  mysql-logs-dev:
+    name: eod_mysql-logs-dev
   loki-data-dev:
     name: eod_loki-data-dev
   alloy-data-dev:

--- a/monitoring/alloy/config.alloy
+++ b/monitoring/alloy/config.alloy
@@ -19,6 +19,11 @@ loki.process "eod_app" {
     expression = "^(?P<timestamp>\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d{3}) (?P<level>[A-Z]+)\\s+\\[(?P<thread>[^\\]]+)\\] (?P<logger>[^ ]+) - (?P<message>.*)$"
   }
 
+  stage.drop {
+    source = "level"
+    value  = "DEBUG"
+  }
+
   stage.timestamp {
     source   = "timestamp"
     format   = "2006-01-02 15:04:05.000"
@@ -37,6 +42,29 @@ loki.process "eod_app" {
       logger = "",
     }
   }
+
+  forward_to = [loki.write.local.receiver]
+}
+
+loki.source.file "mysql" {
+  targets = [
+    {
+      __path__     = "/var/log/mysql/error.log",
+      service_name = "mysql",
+      log_type     = "error",
+      env          = sys.env("ENVIRONMENT"),
+      server       = sys.env("SERVER_NAME"),
+      log_source   = "mysql-file",
+    },
+    {
+      __path__     = "/var/log/mysql/slow.log",
+      service_name = "mysql",
+      log_type     = "slow",
+      env          = sys.env("ENVIRONMENT"),
+      server       = sys.env("SERVER_NAME"),
+      log_source   = "mysql-file",
+    },
+  ]
 
   forward_to = [loki.write.local.receiver]
 }

--- a/monitoring/alloy/config.alloy
+++ b/monitoring/alloy/config.alloy
@@ -20,8 +20,9 @@ loki.process "eod_app" {
   }
 
   stage.timestamp {
-    source = "timestamp"
-    format = "2006-01-02 15:04:05.000"
+    source   = "timestamp"
+    format   = "2006-01-02 15:04:05.000"
+    location = "Asia/Seoul"
   }
 
   stage.labels {

--- a/monitoring/alloy/config.alloy
+++ b/monitoring/alloy/config.alloy
@@ -20,9 +20,8 @@ loki.process "eod_app" {
   }
 
   stage.timestamp {
-    source   = "timestamp"
-    format   = "2006-01-02 15:04:05.000"
-    location = "Asia/Seoul"
+    source = "timestamp"
+    format = "2006-01-02 15:04:05.000"
   }
 
   stage.labels {


### PR DESCRIPTION
## Summary
- 앱 로그 권한 문제 해결: `LOG_DIR=/logs` 하드코딩 (호스트 env 덮어쓰기 방지)
- 컨테이너 timezone을 KST로 통일 (`app`, `alloy`, `mysql`)
- Alloy `stage.timestamp`에 `location=Asia/Seoul` 적용
- MySQL `error.log` + `slow.log`(1초 이상) 파일 출력 후 named volume으로 Alloy 공유
- Alloy 단에서 앱 DEBUG 로그 필터링 (`stage.drop`)

## Test plan
- [ ] Grafana Drilldown > Logs 에 `eod-backend`, `mysql` 두 서비스 표시 확인
- [ ] `eod-backend` 로그에 DEBUG 라인이 안 보이는지 확인
- [ ] `docker exec eod-app-dev tail /logs/application.log` 시 KST 시각으로 표기 확인