### PR TITLE
fix: prod-public 헬스체크 도메인 수정

### DIFF
--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -84,7 +84,7 @@ scrape_configs:
           application: eod
           availability_target: app-internal
       - targets:
-          - "https://www.jojaemin.com/healthz"
+          - "https://eodi.jojaemin.com/healthz"
         labels:
           application: eod
           availability_target: prod-public


### PR DESCRIPTION
## Summary
- `prod-public` 가용성 모니터링 타겟이 dev 도메인(`www.jojaemin.com`)을 바라보고 있던 문제 수정
- prod 도메인(`eodi.jojaemin.com`)으로 변경

## Changes
- `monitoring/prometheus/prometheus.yml`: blackbox-http `prod-public` 타겟 URL 수정

## Test plan
- [ ] Prometheus 컨테이너 재시작 후 `prod-public` 타겟이 `eodi.jojaemin.com/healthz`를 체크하는지 확인
- [ ] Grafana HTTP Availability 패널에서 `prod-public` 상태 정상 표시 확인