### PR TITLE
fix: prod-public 헬스체크 타겟 제거

### DIFF
--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -83,11 +83,6 @@ scrape_configs:
         labels:
           application: eod
           availability_target: app-internal
-      - targets:
-          - "https://eodi.jojaemin.com/healthz"
-        labels:
-          application: eod
-          availability_target: prod-public
     relabel_configs:
       - source_labels: [__address__]
         target_label: __param_target


### PR DESCRIPTION
## Summary
- `prod-public` blackbox 헬스체크 타겟 제거

## 원인
서버가 `eodi.jojaemin.com`(공인 IP)으로 요청을 보내면 공유기가 자기 자신으로 돌려보내지 못하는 **NAT Hairpinning** 문제로 항상 Connection Refused 발생

## 근거
```
wget: can't connect to remote host (125.184.8.79): Connection refused
probe_http_duration_seconds{phase="connect"} 0
```

## 판단
- `app-internal`이 이미 Docker 내부에서 앱 헬스체크를 커버하고 있어 중복
- 진짜 외부 접근성 검증은 같은 서버 내 blackbox-exporter로 구조적으로 불가능
- 필요 시 외부 모니터링 서비스(UptimeRobot 등) 연동으로 대체 예정

## Test plan
- [ ] Prometheus 재시작 후 `prod-public` 타겟이 사라졌는지 확인
- [ ] Grafana HTTP Availability 패널에서 `app-internal`만 표시되는지 확인