### PR TITLE
fix: 가용성 % 패널 쿼리를 app-internal 기준으로 변경

### DIFF
--- a/monitoring/grafana/dashboards/eod-infrastructure.json
+++ b/monitoring/grafana/dashboards/eod-infrastructure.json
@@ -291,7 +291,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "avg_over_time(probe_success{job=\"blackbox-http\", availability_target=\"prod-public\"}[1d]) * 100",
+          "expr": "avg_over_time(probe_success{job=\"blackbox-http\", availability_target=\"app-internal\"}[1d]) * 100",
           "legendFormat": "24h",
           "instant": true,
           "refId": "A"
@@ -302,7 +302,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "avg_over_time(probe_success{job=\"blackbox-http\", availability_target=\"prod-public\"}[7d]) * 100",
+          "expr": "avg_over_time(probe_success{job=\"blackbox-http\", availability_target=\"app-internal\"}[7d]) * 100",
           "legendFormat": "7d",
           "instant": true,
           "refId": "B"
@@ -313,7 +313,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "avg_over_time(probe_success{job=\"blackbox-http\", availability_target=\"prod-public\"}[30d]) * 100",
+          "expr": "avg_over_time(probe_success{job=\"blackbox-http\", availability_target=\"app-internal\"}[30d]) * 100",
           "legendFormat": "30d",
           "instant": true,
           "refId": "C"


### PR DESCRIPTION
## Summary
- 가용성 % 패널(1일/7일/30일)의 쿼리 타겟을 `prod-public` → `app-internal`로 변경

## 배경
- `prod-public` 타겟이 NAT Hairpinning 문제로 제거됨 (#281)
- 제거 후 가용성 % 패널이 빈 패널로 남는 문제 발생
- `app-internal`이 동일하게 앱 헬스체크를 수행하므로 기준으로 대체

## Changes
- `monitoring/grafana/dashboards/eod-infrastructure.json`: 가용성 쿼리 3개 수정

## Test plan
- [ ] Grafana 대시보드에서 가용성 % 패널(1일/7일/30일)에 데이터가 표시되는지 확인