### PR TITLE
feat :: 모든 인바운드 API 요청 INFO 로깅 추가

### DIFF
--- a/src/main/java/com/eod/eod/common/config/SecurityConfig.java
+++ b/src/main/java/com/eod/eod/common/config/SecurityConfig.java
@@ -14,6 +14,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter;
 import org.springframework.security.web.header.writers.StaticHeadersWriter;
 import org.springframework.web.cors.CorsConfigurationSource;
+import com.eod.eod.common.filter.RequestLoggingFilter;
 import com.eod.eod.common.jwt.JwtAuthenticationFilter;
 import com.eod.eod.domain.auth.application.CustomOAuth2UserService;
 import com.eod.eod.domain.auth.application.OAuth2SuccessHandler;
@@ -27,6 +28,7 @@ import com.eod.eod.common.exception.CustomAuthenticationEntryPoint;
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final RequestLoggingFilter requestLoggingFilter;
     private final CustomOAuth2UserService customOAuth2UserService;
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
     private final OAuth2FailureHandler oAuth2FailureHandler;
@@ -148,7 +150,9 @@ public class SecurityConfig {
                         .failureHandler(oAuth2FailureHandler)
                 )
                 // JWT 필터 추가
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                // 요청 로깅 필터: JWT 필터보다 앞에 두어 401/403 응답까지 함께 기록
+                .addFilterBefore(requestLoggingFilter, JwtAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/eod/eod/common/filter/RequestLoggingFilter.java
+++ b/src/main/java/com/eod/eod/common/filter/RequestLoggingFilter.java
@@ -1,0 +1,64 @@
+package com.eod.eod.common.filter;
+
+import com.eod.eod.domain.user.model.User;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@Slf4j
+public class RequestLoggingFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        long start = System.currentTimeMillis();
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            long elapsed = System.currentTimeMillis() - start;
+            String query = request.getQueryString();
+            String path = query != null ? request.getRequestURI() + "?" + query : request.getRequestURI();
+            log.info("API {} {} → {} ({}ms) userId={}",
+                    request.getMethod(),
+                    path,
+                    response.getStatus(),
+                    elapsed,
+                    resolveUserId());
+        }
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        return path.startsWith("/actuator")
+                || path.startsWith("/images/")
+                || path.startsWith("/swagger-ui")
+                || path.startsWith("/v3/api-docs")
+                || path.startsWith("/api-docs")
+                || path.startsWith("/swagger-resources")
+                || path.startsWith("/webjars")
+                || path.equals("/healthz")
+                || path.equals("/favicon.ico");
+    }
+
+    private String resolveUserId() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated()) {
+            return "anonymous";
+        }
+        Object principal = auth.getPrincipal();
+        if (principal instanceof User user) {
+            return String.valueOf(user.getId());
+        }
+        return "anonymous";
+    }
+}

--- a/src/main/java/com/eod/eod/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/eod/eod/common/jwt/JwtAuthenticationFilter.java
@@ -68,9 +68,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
                         // SecurityContext에 인증 정보 설정
                         SecurityContextHolder.getContext().setAuthentication(authentication);
-
-                        log.info("JWT 인증 성공 - userId: {}, userName: {}, role: {}, authorities: {}",
-                                user.getId(), user.getName(), role, authorities);
                     } else {
                         // Access Token이 아닌 경우 (Refresh Token 등)
                         log.warn("Access Token이 아닌 토큰 유형: {}", jwtTokenProvider.getTokenType(token));


### PR DESCRIPTION
## Summary
- `RequestLoggingFilter` 신설: 모든 인바운드 API 요청을 `method`, `path`, `status`, `elapsed`, `userId` 한 줄로 INFO 로깅
- Security 필터 체인에서 `JwtAuthenticationFilter` 앞에 배치 → 401/403 거절도 함께 기록되고 finally 시점에 SecurityContext 가 살아있어 `userId` 추출 가능
- 노이즈 경로(`/actuator`, `/swagger-*`, `/v3/api-docs`, `/api-docs`, `/swagger-resources`, `/webjars`, `/images/`, `/healthz`, `/favicon.ico`) 는 `shouldNotFilter` 로 제외
- `JwtAuthenticationFilter` 의 `JWT 인증 성공` INFO 로그 제거 — 요청 로그와 정보가 중복되며 `userName` PII 가 평문 노출되던 문제 해소

## 출력 예시
```
API GET /items/12?keyword=foo → 200 (45ms) userId=42
API POST /auth/login → 401 (8ms) userId=anonymous
```

## Test plan
- [ ] 인증 성공 요청: `userId=<숫자>` 로 찍히는지
- [ ] 토큰 없는 공개 엔드포인트(`GET /items/*`): `userId=anonymous`
- [ ] 잘못된/만료된 토큰: 401 status 와 `userId=anonymous` 함께 기록되는지
- [ ] 제외 경로(`/actuator/prometheus`, `/healthz`, `/images/...`, `/swagger-ui/...`): 로그 안 찍히는지
- [ ] OncePerRequestFilter 중복 실행 없는지 (한 요청당 한 줄만)
- [ ] Spring Security 거절(403)도 status 와 함께 기록되는지