### PR TITLE
fix: dev 모니터링 스택 중앙화

### DIFF
--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -143,6 +143,7 @@ jobs:
           DISCORD_BOT_TOKEN=${{ secrets.PROD_DISCORD_BOT_TOKEN }}
           DISCORD_GUILD_ID=${{ secrets.PROD_DISCORD_GUILD_ID }}
           DISCORD_VERIFIED_ROLE_ID=${{ secrets.PROD_DISCORD_VERIFIED_ROLE_ID }}
+          DISCORD_STAFF_NOTIFY_IDS=${{ secrets.PROD_DISCORD_STAFF_NOTIFY_IDS }}
           DEV_MYSQL_USER=${{ secrets.DB_USERNAME }}
           DEV_MYSQL_PASSWORD=${{ secrets.DB_PASSWORD }}
           EOF

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -143,6 +143,8 @@ jobs:
           DISCORD_BOT_TOKEN=${{ secrets.PROD_DISCORD_BOT_TOKEN }}
           DISCORD_GUILD_ID=${{ secrets.PROD_DISCORD_GUILD_ID }}
           DISCORD_VERIFIED_ROLE_ID=${{ secrets.PROD_DISCORD_VERIFIED_ROLE_ID }}
+          DEV_MYSQL_USER=${{ secrets.DB_USERNAME }}
+          DEV_MYSQL_PASSWORD=${{ secrets.DB_PASSWORD }}
           EOF
 
           # Alertmanager Discord webhook 설정 파일 생성
@@ -186,6 +188,14 @@ jobs:
           else
             echo "✅ 볼륨이 이미 존재합니다: eod_mysql-data-prod"
           fi
+          for volume in eod_app-logs-dev eod_mysql-logs-dev; do
+            if ! docker volume inspect "$volume" >/dev/null 2>&1; then
+              echo "⚠️  dev 로그 볼륨이 존재하지 않습니다. 새로 생성합니다: $volume"
+              docker volume create "$volume"
+            else
+              echo "✅ dev 로그 볼륨 확인: $volume"
+            fi
+          done
           echo "========================================="
 
           # 로그 디렉토리 생성

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -135,6 +135,7 @@ jobs:
           DISCORD_BOT_TOKEN=${{ secrets.DISCORD_BOT_TOKEN }}
           DISCORD_GUILD_ID=${{ secrets.DISCORD_GUILD_ID }}
           DISCORD_VERIFIED_ROLE_ID=${{ secrets.DISCORD_VERIFIED_ROLE_ID }}
+          DISCORD_STAFF_NOTIFY_IDS=${{ secrets.DISCORD_STAFF_NOTIFY_IDS }}
           EOF
           
           # GitHub Container Registry 로그인

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -165,7 +165,7 @@ jobs:
             echo "Pull 실패, 30초 후 재시도..."
             [ $i -lt 3 ] && sleep 30 || { echo "❌ Pull 최종 실패"; exit 1; }
           done
-          docker compose -f docker-compose.yml down
+          docker compose -f docker-compose.yml --profile monitoring down --remove-orphans
           docker compose -f docker-compose.yml up -d --remove-orphans
 
           # 배포 직후 상태 확인

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -66,6 +66,8 @@ services:
     image: prom/prometheus:v2.54.1
     container_name: eod-prometheus
     restart: always
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     ports:
       - "127.0.0.1:9091:9090"
     volumes:
@@ -120,6 +122,20 @@ services:
     networks:
       - eod-network
 
+  mysqld-exporter-dev:
+    image: prom/mysqld-exporter:v0.19.0
+    container_name: eod-mysqld-exporter-dev-central
+    restart: always
+    command:
+      - --mysqld.address=host.docker.internal:3306
+      - --mysqld.username=${DEV_MYSQL_USER:-${MYSQL_USER}}
+    environment:
+      - MYSQLD_EXPORTER_PASSWORD=${DEV_MYSQL_PASSWORD:-${MYSQL_PASSWORD}}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    networks:
+      - eod-network
+
   blackbox-exporter:
     image: prom/blackbox-exporter:v0.27.0
     container_name: eod-blackbox-exporter
@@ -170,8 +186,10 @@ services:
       - TZ=Asia/Seoul
     volumes:
       - ./monitoring/alloy/config.alloy:/etc/alloy/config.alloy:ro
-      - app-logs-prod:/var/log/eod:ro
-      - mysql-logs-prod:/var/log/mysql:ro
+      - app-logs-prod:/var/log/eod/prod:ro
+      - app-logs-dev:/var/log/eod/dev:ro
+      - mysql-logs-prod:/var/log/mysql/prod:ro
+      - mysql-logs-dev:/var/log/mysql/dev:ro
       - alloy-data-prod:/var/lib/alloy
     depends_on:
       loki:
@@ -209,6 +227,12 @@ volumes:
     name: eod_app-logs-prod
   mysql-logs-prod:
     name: eod_mysql-logs-prod
+  app-logs-dev:
+    external: true
+    name: eod_app-logs-dev
+  mysql-logs-dev:
+    external: true
+    name: eod_mysql-logs-dev
   loki-data-prod:
     name: eod_loki-data-prod
   alloy-data-prod:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     restart: always
     ports:
       - "8000:8080"
+      - "127.0.0.1:8082:8081"
     environment:
       - SPRING_DATASOURCE_URL=${SPRING_DATASOURCE_URL}
       - SPRING_DATASOURCE_USERNAME=${SPRING_DATASOURCE_USERNAME}
@@ -23,6 +24,7 @@ services:
       - BSM_CLIENT_SECRET=${BSM_CLIENT_SECRET}
       - BSM_OAUTH_BASE_URL=${BSM_OAUTH_BASE_URL}
       - BSM_REDIRECT_URI=${BSM_REDIRECT_URI}
+      - MANAGEMENT_SERVER_PORT=${MANAGEMENT_SERVER_PORT:-8081}
       - FILE_UPLOAD_DIR=/eod/uploads
       - FILE_UPLOAD_BASE_URL=${FILE_UPLOAD_BASE_URL}
       - DISCORD_BOT_TOKEN=${DISCORD_BOT_TOKEN}
@@ -64,6 +66,7 @@ services:
       retries: 10
 
   prometheus:
+    profiles: ["monitoring"]
     image: prom/prometheus:v2.54.1
     container_name: eod-prometheus-dev
     restart: always
@@ -76,6 +79,7 @@ services:
       - eod-network-dev
 
   node-exporter:
+    profiles: ["monitoring"]
     image: prom/node-exporter:v1.9.1
     container_name: eod-node-exporter-dev
     restart: always
@@ -88,6 +92,7 @@ services:
       - eod-network-dev
 
   cadvisor:
+    profiles: ["monitoring"]
     image: gcr.io/cadvisor/cadvisor:v0.52.1
     container_name: eod-cadvisor-dev
     restart: always
@@ -102,6 +107,7 @@ services:
       - eod-network-dev
 
   mysqld-exporter:
+    profiles: ["monitoring"]
     image: prom/mysqld-exporter:v0.19.0
     container_name: eod-mysqld-exporter-dev
     restart: always
@@ -117,6 +123,7 @@ services:
       - eod-network-dev
 
   blackbox-exporter:
+    profiles: ["monitoring"]
     image: prom/blackbox-exporter:v0.27.0
     container_name: eod-blackbox-exporter-dev
     restart: always
@@ -130,6 +137,7 @@ services:
       - eod-network-dev
 
   loki:
+    profiles: ["monitoring"]
     image: grafana/loki:3.7.0
     container_name: eod-loki-dev
     restart: always
@@ -144,6 +152,7 @@ services:
       - eod-network-dev
 
   alloy:
+    profiles: ["monitoring"]
     image: grafana/alloy:v1.11.3
     container_name: eod-alloy-dev
     restart: always
@@ -169,6 +178,7 @@ services:
       - eod-network-dev
 
   grafana:
+    profiles: ["monitoring"]
     image: grafana/grafana:12.4.0
     container_name: eod-grafana-dev
     restart: always

--- a/docs/superpowers/plans/2026-05-16-central-dev-monitoring.md
+++ b/docs/superpowers/plans/2026-05-16-central-dev-monitoring.md
@@ -1,0 +1,75 @@
+# Central Dev Monitoring Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [x]`) syntax for tracking.
+
+**Goal:** Keep dev continuously monitored without running a second full monitoring stack.
+
+**Architecture:** Production keeps the only Prometheus, Grafana, Loki, Alloy, node-exporter, and cAdvisor stack. Dev runs only the app and MySQL by default; production Prometheus scrapes dev app metrics through a loopback-published management port, production cAdvisor/node-exporter cover dev containers and host resources, production Alloy tails dev log volumes, and production runs a lightweight MySQL exporter for the dev database.
+
+**Tech Stack:** Docker Compose, Prometheus, Grafana Alloy, Loki, Spring Boot Actuator, mysqld-exporter.
+
+---
+
+## Chunk 1: Compose Wiring
+
+### Task 1: Expose Dev App Metrics Internally
+
+**Files:**
+- Modify: `docker-compose.yml`
+
+- [x] Add `MANAGEMENT_SERVER_PORT=${MANAGEMENT_SERVER_PORT:-8081}` to the dev app environment.
+- [x] Publish the dev management port on loopback only, using host port `8082`.
+- [x] Validate with `docker compose -f docker-compose.yml config`.
+
+### Task 2: Let Production Monitoring Reach Host-Published Dev Targets
+
+**Files:**
+- Modify: `docker-compose.prod.yml`
+
+- [x] Add `extra_hosts: ["host.docker.internal:host-gateway"]` to production Prometheus.
+- [x] Add a lightweight `mysqld-exporter-dev` service to production compose.
+- [x] Mount dev app and MySQL log volumes into production Alloy as read-only external volumes.
+- [x] Declare the dev log volumes as external named volumes.
+- [x] Validate with `docker compose -f docker-compose.prod.yml config`.
+
+## Chunk 2: Prometheus and Alloy Labels
+
+### Task 3: Add Dev Metrics Scrape Targets
+
+**Files:**
+- Modify: `monitoring/prometheus/prometheus.yml`
+
+- [x] Add `env="prod"` to existing production scrape targets.
+- [x] Add a dev app scrape target for `host.docker.internal:8082`.
+- [x] Add a dev MySQL scrape target for `mysqld-exporter-dev:9104`.
+- [x] Keep host/container metrics central and label them as `env="shared"`.
+- [x] Validate Prometheus YAML parsing.
+
+### Task 4: Tail Prod and Dev Logs Separately
+
+**Files:**
+- Modify: `monitoring/alloy/config.alloy`
+
+- [x] Split app file targets into production and dev paths with distinct `env` and `container` labels.
+- [x] Split MySQL log targets into production and dev paths with distinct `env` labels.
+- [x] Validate Alloy config rendering enough for compose config to mount it.
+
+## Chunk 3: Docs and Verification
+
+### Task 5: Update Operations Documentation
+
+**Files:**
+- Modify: `monitoring/README.md`
+
+- [x] Document that dev remains monitored centrally.
+- [x] Document the dev management port and dev MySQL exporter location.
+- [x] Document prod/dev log labels.
+
+### Task 6: Verify Configuration
+
+**Commands:**
+- [x] `docker compose -f docker-compose.yml config`
+- [x] `docker compose -f docker-compose.yml config --services` should return only `mysql` and `app` by default.
+- [x] `docker compose -f docker-compose.prod.yml config`
+- [x] `ruby -e 'require "yaml"; YAML.load_file("monitoring/prometheus/prometheus.yml"); YAML.load_file("monitoring/prometheus/alerts/eod-alerts.yml"); puts "yaml ok"'`
+- [x] `git diff --check`

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -8,6 +8,42 @@
 - Prometheus is bound to `127.0.0.1` in production. Grafana is published on port `3002` for external access and must use a strong `GRAFANA_ADMIN_PASSWORD`.
 - Alertmanager stays on the internal Docker network and receives alerts directly from Prometheus.
 
+## Development monitoring policy
+
+The development compose file keeps the application and MySQL running by default. The full dev monitoring stack remains opt-in through the `monitoring` profile for temporary local troubleshooting, but continuous dev monitoring is handled by the production monitoring stack.
+
+In the normal same-LXC deployment:
+
+- Production runs the only Prometheus, Grafana, Loki, Alloy, Node Exporter, and cAdvisor stack.
+- Dev runs `app` and `mysql` by default.
+- Dev app metrics are exposed only on loopback as `127.0.0.1:8082`, forwarded to the app management port `8081`.
+- Production Prometheus scrapes dev app metrics through `host.docker.internal:8082`.
+- Production runs `mysqld-exporter-dev`, which connects to dev MySQL through `host.docker.internal:3306`.
+- Production Alloy tails both prod and dev log volumes and labels entries with `env="prod"` or `env="dev"`.
+
+This keeps dev visible while avoiding a second Prometheus, Grafana, Loki, Alloy, Node Exporter, and cAdvisor stack during normal deployments.
+
+Default dev deployment:
+
+```bash
+docker compose -f docker-compose.yml up -d
+```
+
+Temporary dev monitoring:
+
+```bash
+docker compose -f docker-compose.yml --profile monitoring up -d
+```
+
+The dev CD workflow runs `docker compose -f docker-compose.yml --profile monitoring down --remove-orphans` before starting the default services, so older dev monitoring containers are removed during the next deployment.
+
+Production deployment requires the dev MySQL credentials in:
+
+- `DEV_MYSQL_USER`
+- `DEV_MYSQL_PASSWORD`
+
+The GitHub production CD workflow fills these from the existing dev database secrets.
+
 ## Required production environment variables
 
 - `GRAFANA_ADMIN_USER`
@@ -41,7 +77,7 @@ The monitoring stack collects metrics from:
 - Spring Boot Actuator: HTTP, JVM, HikariCP, and EOD custom domain metrics
 - Node Exporter: host CPU, memory, disk, inode, and network metrics
 - cAdvisor: Docker container resource metrics
-- MySQL Exporter: MySQL health, connections, and server metrics
+- MySQL Exporter: prod and dev MySQL health, connections, and server metrics
 - Blackbox Exporter: internal and public HTTP availability checks
 - Loki, Alloy, Grafana, and Prometheus self metrics
 
@@ -51,7 +87,10 @@ Dashboard files:
 
 - `monitoring/grafana/dashboards/eod-overview.json`: application HTTP/JVM/DB overview
 - `monitoring/grafana/dashboards/eod-infrastructure.json`: server, container, MySQL, and availability metrics
+- `monitoring/grafana/dashboards/eod-jvm.json`: JVM memory, GC, threads, and classes
 - `monitoring/grafana/dashboards/eod-domain-metrics.json`: EOD business/domain metrics
+
+Application, JVM, and domain dashboards include an `env` variable so prod and dev metrics can be viewed separately from the same Grafana instance.
 
 Domain metric names:
 
@@ -68,15 +107,15 @@ Domain metric names:
 
 ## Logs
 
-Application logs are written by Logback to `/logs/application.log` inside the app container. In production, `docker-compose.prod.yml` mounts host `/eod/prod/logs` to that path.
+Application logs are written by Logback to `/logs/application.log` inside each app container. In production, `docker-compose.prod.yml` mounts the named volume `app-logs-prod` to that path. In dev, `docker-compose.yml` mounts `app-logs-dev`.
 
-Grafana Alloy tails `/eod/prod/logs/application.log` through a read-only mount, parses the current Logback text format, attaches labels, and sends entries to Loki. Loki stays on the internal Docker network; Grafana is the user-facing access point for Explore and Drilldown > Logs.
+Production Grafana Alloy tails both `/var/log/eod/prod/application.log` and `/var/log/eod/dev/application.log` through read-only mounts, parses the current Logback text format, attaches labels, and sends entries to Loki. Loki stays on the internal Docker network; Grafana is the user-facing access point for Explore and Drilldown > Logs.
 
 Important Loki labels:
 
 - `service_name="eod-backend"`: primary service label for Logs Drilldown
 - `server="eod-prod-01"`: production server label configured in `docker-compose.prod.yml`
-- `env="prod"`: production environment label configured in `docker-compose.prod.yml`
+- `env="prod"` or `env="dev"`: source environment label
 - `container`: Docker container role
 - `level`: parsed log severity
 
@@ -84,6 +123,7 @@ Direct LogQL check:
 
 ```logql
 {service_name="eod-backend", server="eod-prod-01"}
+{service_name="eod-backend", env="dev"}
 ```
 
 Operational checks:

--- a/monitoring/alloy/config.alloy
+++ b/monitoring/alloy/config.alloy
@@ -1,12 +1,21 @@
 loki.source.file "eod_app" {
   targets = [
     {
-      __path__      = "/var/log/eod/application.log",
+      __path__      = "/var/log/eod/prod/application.log",
       service_name  = "eod-backend",
       app           = "eod",
-      env           = sys.env("ENVIRONMENT"),
+      env           = "prod",
       server        = sys.env("SERVER_NAME"),
       container     = sys.env("APP_CONTAINER_NAME"),
+      log_source    = "spring-file",
+    },
+    {
+      __path__      = "/var/log/eod/dev/application.log",
+      service_name  = "eod-backend",
+      app           = "eod",
+      env           = "dev",
+      server        = sys.env("SERVER_NAME"),
+      container     = "eod-app-dev",
       log_source    = "spring-file",
     },
   ]
@@ -49,18 +58,34 @@ loki.process "eod_app" {
 loki.source.file "mysql" {
   targets = [
     {
-      __path__     = "/var/log/mysql/error.log",
+      __path__     = "/var/log/mysql/prod/error.log",
       service_name = "mysql",
       log_type     = "error",
-      env          = sys.env("ENVIRONMENT"),
+      env          = "prod",
       server       = sys.env("SERVER_NAME"),
       log_source   = "mysql-file",
     },
     {
-      __path__     = "/var/log/mysql/slow.log",
+      __path__     = "/var/log/mysql/prod/slow.log",
       service_name = "mysql",
       log_type     = "slow",
-      env          = sys.env("ENVIRONMENT"),
+      env          = "prod",
+      server       = sys.env("SERVER_NAME"),
+      log_source   = "mysql-file",
+    },
+    {
+      __path__     = "/var/log/mysql/dev/error.log",
+      service_name = "mysql",
+      log_type     = "error",
+      env          = "dev",
+      server       = sys.env("SERVER_NAME"),
+      log_source   = "mysql-file",
+    },
+    {
+      __path__     = "/var/log/mysql/dev/slow.log",
+      service_name = "mysql",
+      log_type     = "slow",
+      env          = "dev",
       server       = sys.env("SERVER_NAME"),
       log_source   = "mysql-file",
     },

--- a/monitoring/grafana/dashboards/eod-domain-metrics.json
+++ b/monitoring/grafana/dashboards/eod-domain-metrics.json
@@ -77,7 +77,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum by (domain, action, result) (increase(eod_business_events_total[5m]))",
+          "expr": "sum by (domain, action, result) (increase(eod_business_events_total{env=~\"$env\"}[5m]))",
           "legendFormat": "{{ domain }} / {{ action }} / {{ result }}",
           "range": true,
           "refId": "A"
@@ -152,7 +152,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum by (domain, action) (increase(eod_business_events_total{result=\"failure\"}[10m]))",
+          "expr": "sum by (domain, action) (increase(eod_business_events_total{env=~\"$env\",result=\"failure\"}[10m]))",
           "legendFormat": "{{ domain }} / {{ action }}",
           "range": true,
           "refId": "A"
@@ -222,7 +222,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "eod_items_current",
+          "expr": "eod_items_current{env=~\"$env\"}",
           "legendFormat": "{{ status }}",
           "range": true,
           "refId": "A"
@@ -292,7 +292,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "eod_claims_current",
+          "expr": "eod_claims_current{env=~\"$env\"}",
           "legendFormat": "{{ status }}",
           "range": true,
           "refId": "A"
@@ -355,7 +355,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "eod_reward_eligible_items",
+          "expr": "eod_reward_eligible_items{env=~\"$env\"}",
           "legendFormat": "eligible",
           "range": true,
           "refId": "A"
@@ -366,7 +366,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "eod_reward_records_current",
+          "expr": "eod_reward_records_current{env=~\"$env\"}",
           "legendFormat": "records",
           "range": true,
           "refId": "B"
@@ -434,7 +434,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by (le, operation, result) (rate(eod_external_call_seconds_bucket[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le, operation, result) (rate(eod_external_call_seconds_bucket{env=~\"$env\"}[5m])))",
           "legendFormat": "{{ operation }} / {{ result }}",
           "range": true,
           "refId": "A"
@@ -501,7 +501,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum by (result) (increase(eod_business_events_total{domain=\"image\",action=\"upload\"}[5m]))",
+          "expr": "sum by (result) (increase(eod_business_events_total{env=~\"$env\",domain=\"image\",action=\"upload\"}[5m]))",
           "legendFormat": "{{ result }}",
           "range": true,
           "refId": "A"
@@ -568,7 +568,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum by (task, result) (increase(eod_scheduler_runs_total[1h]))",
+          "expr": "sum by (task, result) (increase(eod_scheduler_runs_total{env=~\"$env\"}[1h]))",
           "legendFormat": "{{ task }} / {{ result }}",
           "range": true,
           "refId": "A"
@@ -579,7 +579,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum by (task) (increase(eod_scheduler_processed_items_sum[1h]))",
+          "expr": "sum by (task) (increase(eod_scheduler_processed_items_sum{env=~\"$env\"}[1h]))",
           "legendFormat": "{{ task }} processed",
           "range": true,
           "refId": "B"
@@ -598,7 +598,7 @@
     "domain"
   ],
   "templating": {
-    "list": []
+    "list": [{"name":"env","type":"query","datasource":{"type":"prometheus","uid":"prometheus"},"query":"label_values(up, env)","refresh":1,"sort":1,"current":{"text":"prod","value":"prod"},"includeAll":false,"multi":false}]
   },
   "time": {
     "from": "now-6h",

--- a/monitoring/grafana/dashboards/eod-jvm.json
+++ b/monitoring/grafana/dashboards/eod-jvm.json
@@ -21,7 +21,7 @@
   "schemaVersion": 39,
   "style": "dark",
   "tags": ["eod", "prometheus", "jvm"],
-  "templating": {"list": []},
+  "templating": {"list": [{"name":"env","type":"query","datasource":{"type":"prometheus","uid":"prometheus"},"query":"label_values(up, env)","refresh":1,"sort":1,"current":{"text":"prod","value":"prod"},"includeAll":false,"multi":false}]},
   "time": {"from": "now-6h", "to": "now"},
   "timepicker": {},
   "timezone": "",
@@ -49,21 +49,21 @@
         {
           "datasource": {"type": "prometheus", "uid": "prometheus"},
           "editorMode": "code",
-          "expr": "sum(jvm_memory_used_bytes{application=\"eod\", area=\"heap\"})",
+          "expr": "sum(jvm_memory_used_bytes{application=\"eod\",env=~\"$env\", area=\"heap\"})",
           "legendFormat": "used",
           "refId": "A"
         },
         {
           "datasource": {"type": "prometheus", "uid": "prometheus"},
           "editorMode": "code",
-          "expr": "sum(jvm_memory_committed_bytes{application=\"eod\", area=\"heap\"})",
+          "expr": "sum(jvm_memory_committed_bytes{application=\"eod\",env=~\"$env\", area=\"heap\"})",
           "legendFormat": "committed",
           "refId": "B"
         },
         {
           "datasource": {"type": "prometheus", "uid": "prometheus"},
           "editorMode": "code",
-          "expr": "sum(jvm_memory_max_bytes{application=\"eod\", area=\"heap\"} > 0)",
+          "expr": "sum(jvm_memory_max_bytes{application=\"eod\",env=~\"$env\", area=\"heap\"} > 0)",
           "legendFormat": "max",
           "refId": "C"
         }
@@ -90,7 +90,7 @@
         {
           "datasource": {"type": "prometheus", "uid": "prometheus"},
           "editorMode": "code",
-          "expr": "sum by (id) (jvm_memory_used_bytes{application=\"eod\", area=\"nonheap\"})",
+          "expr": "sum by (id) (jvm_memory_used_bytes{application=\"eod\",env=~\"$env\", area=\"nonheap\"})",
           "legendFormat": "{{id}}",
           "refId": "A"
         }
@@ -117,7 +117,7 @@
         {
           "datasource": {"type": "prometheus", "uid": "prometheus"},
           "editorMode": "code",
-          "expr": "sum by (action, cause) (rate(jvm_gc_pause_seconds_sum{application=\"eod\"}[5m]))",
+          "expr": "sum by (action, cause) (rate(jvm_gc_pause_seconds_sum{application=\"eod\",env=~\"$env\"}[5m]))",
           "legendFormat": "{{action}} / {{cause}}",
           "refId": "A"
         }
@@ -144,7 +144,7 @@
         {
           "datasource": {"type": "prometheus", "uid": "prometheus"},
           "editorMode": "code",
-          "expr": "sum by (action) (rate(jvm_gc_pause_seconds_count{application=\"eod\"}[5m])) * 60",
+          "expr": "sum by (action) (rate(jvm_gc_pause_seconds_count{application=\"eod\",env=~\"$env\"}[5m])) * 60",
           "legendFormat": "{{action}}",
           "refId": "A"
         }
@@ -171,21 +171,21 @@
         {
           "datasource": {"type": "prometheus", "uid": "prometheus"},
           "editorMode": "code",
-          "expr": "jvm_threads_live_threads{application=\"eod\"}",
+          "expr": "jvm_threads_live_threads{application=\"eod\",env=~\"$env\"}",
           "legendFormat": "live",
           "refId": "A"
         },
         {
           "datasource": {"type": "prometheus", "uid": "prometheus"},
           "editorMode": "code",
-          "expr": "jvm_threads_daemon_threads{application=\"eod\"}",
+          "expr": "jvm_threads_daemon_threads{application=\"eod\",env=~\"$env\"}",
           "legendFormat": "daemon",
           "refId": "B"
         },
         {
           "datasource": {"type": "prometheus", "uid": "prometheus"},
           "editorMode": "code",
-          "expr": "jvm_threads_peak_threads{application=\"eod\"}",
+          "expr": "jvm_threads_peak_threads{application=\"eod\",env=~\"$env\"}",
           "legendFormat": "peak",
           "refId": "C"
         }
@@ -212,7 +212,7 @@
         {
           "datasource": {"type": "prometheus", "uid": "prometheus"},
           "editorMode": "code",
-          "expr": "jvm_classes_loaded_classes{application=\"eod\"}",
+          "expr": "jvm_classes_loaded_classes{application=\"eod\",env=~\"$env\"}",
           "legendFormat": "loaded",
           "refId": "A"
         }

--- a/monitoring/grafana/dashboards/eod-overview.json
+++ b/monitoring/grafana/dashboards/eod-overview.json
@@ -60,7 +60,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(rate(http_server_requests_seconds_count{application=\"eod\",uri!=\"UNKNOWN\"}[5m]))",
+          "expr": "sum(rate(http_server_requests_seconds_count{application=\"eod\",env=~\"$env\",uri!=\"UNKNOWN\"}[5m]))",
           "legendFormat": "total rps",
           "refId": "A"
         }
@@ -107,7 +107,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_requests_seconds_bucket{application=\"eod\",uri!=\"UNKNOWN\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_requests_seconds_bucket{application=\"eod\",env=~\"$env\",uri!=\"UNKNOWN\"}[5m])))",
           "legendFormat": "p95 latency",
           "refId": "A"
         }
@@ -155,7 +155,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(rate(http_server_requests_seconds_count{application=\"eod\",uri!=\"UNKNOWN\"}[5m])) by (status)",
+          "expr": "sum(rate(http_server_requests_seconds_count{application=\"eod\",env=~\"$env\",uri!=\"UNKNOWN\"}[5m])) by (status)",
           "legendFormat": "{{status}}",
           "refId": "A"
         }
@@ -203,7 +203,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(hikaricp_connections_active{application=\"eod\"})",
+          "expr": "sum(hikaricp_connections_active{application=\"eod\",env=~\"$env\"})",
           "legendFormat": "active connections",
           "refId": "A"
         },
@@ -212,7 +212,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(hikaricp_connections_idle{application=\"eod\"})",
+          "expr": "sum(hikaricp_connections_idle{application=\"eod\",env=~\"$env\"})",
           "legendFormat": "idle connections",
           "refId": "B"
         }
@@ -230,7 +230,7 @@
     "prometheus"
   ],
   "templating": {
-    "list": []
+    "list": [{"name":"env","type":"query","datasource":{"type":"prometheus","uid":"prometheus"},"query":"label_values(up, env)","refresh":1,"sort":1,"current":{"text":"prod","value":"prod"},"includeAll":false,"multi":false}]
   },
   "time": {
     "from": "now-6h",

--- a/monitoring/prometheus/alerts/eod-alerts.yml
+++ b/monitoring/prometheus/alerts/eod-alerts.yml
@@ -11,12 +11,22 @@ groups:
           summary: EOD application target is down
           description: Prometheus has not been able to scrape the dockerized EOD application for 2 minutes.
 
+      - alert: EodDevAppDown
+        expr: up{job="eod-app-dev"} == 0
+        for: 5m
+        labels:
+          severity: warning
+          service: eod-dev
+        annotations:
+          summary: EOD dev application metrics target is down
+          description: Prometheus has not been able to scrape the dev EOD application for 5 minutes.
+
       - alert: EodHighHttp5xxRatio
         expr: |
           (
-            sum(rate(http_server_requests_seconds_count{application="eod",status=~"5..",uri!="UNKNOWN"}[5m]))
+            sum(rate(http_server_requests_seconds_count{application="eod",env="prod",status=~"5..",uri!="UNKNOWN"}[5m]))
             /
-            clamp_min(sum(rate(http_server_requests_seconds_count{application="eod",uri!="UNKNOWN"}[5m])), 1)
+            clamp_min(sum(rate(http_server_requests_seconds_count{application="eod",env="prod",uri!="UNKNOWN"}[5m])), 1)
           ) > 0.05
         for: 10m
         labels:
@@ -30,7 +40,7 @@ groups:
         expr: |
           histogram_quantile(
             0.95,
-            sum by (le) (rate(http_server_requests_seconds_bucket{application="eod",uri!="UNKNOWN"}[5m]))
+            sum by (le) (rate(http_server_requests_seconds_bucket{application="eod",env="prod",uri!="UNKNOWN"}[5m]))
           ) > 1
         for: 10m
         labels:
@@ -43,9 +53,9 @@ groups:
       - alert: EodHighJvmHeapUsage
         expr: |
           (
-            sum(jvm_memory_used_bytes{application="eod",area="heap"})
+            sum(jvm_memory_used_bytes{application="eod",env="prod",area="heap"})
             /
-            clamp_min(sum(jvm_memory_max_bytes{application="eod",area="heap"}), 1)
+            clamp_min(sum(jvm_memory_max_bytes{application="eod",env="prod",area="heap"}), 1)
           ) > 0.90
         for: 15m
         labels:
@@ -56,7 +66,7 @@ groups:
           description: JVM heap usage has exceeded 90% for 15 minutes.
 
       - alert: EodHikariPendingConnections
-        expr: sum(hikaricp_connections_pending{application="eod"}) > 0
+        expr: sum(hikaricp_connections_pending{application="eod",env="prod"}) > 0
         for: 5m
         labels:
           severity: warning
@@ -68,9 +78,9 @@ groups:
       - alert: EodHighGcPauseAverage
         expr: |
           (
-            sum(rate(jvm_gc_pause_seconds_sum{application="eod"}[5m]))
+            sum(rate(jvm_gc_pause_seconds_sum{application="eod",env="prod"}[5m]))
             /
-            clamp_min(sum(rate(jvm_gc_pause_seconds_count{application="eod"}[5m])), 1)
+            clamp_min(sum(rate(jvm_gc_pause_seconds_count{application="eod",env="prod"}[5m])), 1)
           ) > 0.2
         for: 10m
         labels:
@@ -81,7 +91,7 @@ groups:
           description: Average JVM GC pause has stayed above 200ms for 10 minutes.
 
       - alert: EodSchedulerFailure
-        expr: increase(eod_scheduler_runs_total{result=~"failure|partial_failure"}[1h]) > 0
+        expr: increase(eod_scheduler_runs_total{env="prod",result=~"failure|partial_failure"}[1h]) > 0
         for: 0m
         labels:
           severity: warning
@@ -187,6 +197,16 @@ groups:
         annotations:
           summary: EOD MySQL is down
           description: MySQL exporter cannot connect to MySQL for 2 minutes.
+
+      - alert: EodDevMysqlDown
+        expr: mysql_up{job="mysql-dev"} == 0
+        for: 5m
+        labels:
+          severity: warning
+          service: eod-dev
+        annotations:
+          summary: EOD dev MySQL is down
+          description: Dev MySQL exporter cannot connect to MySQL for 5 minutes.
 
       - alert: EodMysqlHighConnectionUsage
         expr: |

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -11,14 +11,6 @@ alerting:
         - targets: ["alertmanager:9093"]
 
 scrape_configs:
-  - job_name: "eod-app-local"
-    metrics_path: /actuator/prometheus
-    static_configs:
-      - targets: ["host.docker.internal:8081"]
-        labels:
-          application: eod
-          runtime: local
-
   - job_name: "eod-app-docker"
     metrics_path: /actuator/prometheus
     static_configs:
@@ -26,10 +18,22 @@ scrape_configs:
         labels:
           application: eod
           runtime: docker
+          env: prod
+
+  - job_name: "eod-app-dev"
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: ["host.docker.internal:8082"]
+        labels:
+          application: eod
+          runtime: docker
+          env: dev
 
   - job_name: "prometheus"
     static_configs:
       - targets: ["prometheus:9090"]
+        labels:
+          env: prod
 
   - job_name: "node-exporter"
     static_configs:
@@ -37,6 +41,7 @@ scrape_configs:
         labels:
           application: eod
           component: node
+          env: shared
 
   - job_name: "cadvisor"
     static_configs:
@@ -44,6 +49,7 @@ scrape_configs:
         labels:
           application: eod
           component: containers
+          env: shared
 
   - job_name: "mysql"
     static_configs:
@@ -51,6 +57,15 @@ scrape_configs:
         labels:
           application: eod
           component: mysql
+          env: prod
+
+  - job_name: "mysql-dev"
+    static_configs:
+      - targets: ["mysqld-exporter-dev:9104"]
+        labels:
+          application: eod
+          component: mysql
+          env: dev
 
   - job_name: "loki"
     static_configs:
@@ -58,6 +73,7 @@ scrape_configs:
         labels:
           application: eod
           component: loki
+          env: prod
 
   - job_name: "alloy"
     static_configs:
@@ -65,6 +81,7 @@ scrape_configs:
         labels:
           application: eod
           component: alloy
+          env: prod
 
   - job_name: "grafana"
     static_configs:
@@ -72,6 +89,7 @@ scrape_configs:
         labels:
           application: eod
           component: grafana
+          env: prod
 
   - job_name: "blackbox-http"
     metrics_path: /probe
@@ -83,6 +101,7 @@ scrape_configs:
         labels:
           application: eod
           availability_target: app-internal
+          env: prod
     relabel_configs:
       - source_labels: [__address__]
         target_label: __param_target


### PR DESCRIPTION
## 요약
- dev에서 별도 전체 모니터링 스택을 계속 띄우지 않고, prod 모니터링 스택이 dev까지 중앙 수집하도록 변경했습니다.
- dev 앱 메트릭은 loopback management port로 노출하고, prod 쪽에 dev MySQL exporter를 추가했습니다.
- prod Alloy가 dev 로그 volume까지 읽도록 연결하고, Prometheus/Grafana는 `env` 라벨로 prod/dev를 분리 조회하게 했습니다.

## 테스트
- [x] `docker compose -f docker-compose.yml config`
- [x] `docker compose -f docker-compose.yml config --services`
- [x] `docker compose -f docker-compose.prod.yml config`
- [x] Prometheus/alert YAML 파싱
- [x] Grafana dashboard JSON 파싱
- [x] `git diff --check`
- [x] `./gradlew test`

Closes #288