### PR TITLE
fix: dev 모니터링 scrape 경로 수정

### DIFF
--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -199,6 +199,17 @@ jobs:
           done
           echo "========================================="
 
+          # 중앙 모니터링이 dev 컨테이너에 직접 접근할 공유 네트워크 확인 및 생성
+          echo "========================================="
+          echo "🌐 dev 모니터링 공유 네트워크 확인 중..."
+          if ! docker network inspect eod-network-dev >/dev/null 2>&1; then
+            docker network create eod-network-dev
+            echo "✅ 네트워크 생성 완료: eod-network-dev"
+          else
+            echo "✅ 네트워크가 이미 존재합니다: eod-network-dev"
+          fi
+          echo "========================================="
+
           # 로그 디렉토리 생성
           echo "========================================="
           echo "📁 로그 디렉토리 생성 중..."

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -156,6 +156,17 @@ jobs:
           fi
           echo "========================================="
 
+          # 중앙 모니터링 공유 네트워크 확인 및 생성
+          echo "========================================="
+          echo "🌐 dev 모니터링 공유 네트워크 확인 중..."
+          if ! docker network inspect eod-network-dev >/dev/null 2>&1; then
+            docker network create eod-network-dev
+            echo "✅ 네트워크 생성 완료: eod-network-dev"
+          else
+            echo "✅ 네트워크가 이미 존재합니다: eod-network-dev"
+          fi
+          echo "========================================="
+
           # Docker Compose로 배포
           echo "========================================="
           echo "🚀 Docker Compose 배포 시작"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -66,8 +66,6 @@ services:
     image: prom/prometheus:v2.54.1
     container_name: eod-prometheus
     restart: always
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
     ports:
       - "127.0.0.1:9091:9090"
     volumes:
@@ -80,6 +78,7 @@ services:
         condition: service_started
     networks:
       - eod-network
+      - eod-network-dev
 
   node-exporter:
     image: prom/node-exporter:v1.9.1
@@ -127,14 +126,13 @@ services:
     container_name: eod-mysqld-exporter-dev-central
     restart: always
     command:
-      - --mysqld.address=host.docker.internal:3306
+      - --mysqld.address=eod-mysql-dev:3306
       - --mysqld.username=${DEV_MYSQL_USER:-${MYSQL_USER}}
     environment:
       - MYSQLD_EXPORTER_PASSWORD=${DEV_MYSQL_PASSWORD:-${MYSQL_PASSWORD}}
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
     networks:
       - eod-network
+      - eod-network-dev
 
   blackbox-exporter:
     image: prom/blackbox-exporter:v0.27.0
@@ -241,3 +239,6 @@ volumes:
 networks:
   eod-network:
     driver: bridge
+  eod-network-dev:
+    external: true
+    name: eod-network-dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@ services:
     restart: always
     ports:
       - "8000:8080"
-      - "127.0.0.1:8082:8081"
     environment:
       - SPRING_DATASOURCE_URL=${SPRING_DATASOURCE_URL}
       - SPRING_DATASOURCE_USERNAME=${SPRING_DATASOURCE_USERNAME}
@@ -215,4 +214,5 @@ volumes:
 
 networks:
   eod-network-dev:
-    driver: bridge
+    external: true
+    name: eod-network-dev

--- a/docs/superpowers/plans/2026-05-16-central-dev-monitoring.md
+++ b/docs/superpowers/plans/2026-05-16-central-dev-monitoring.md
@@ -18,7 +18,7 @@
 - Modify: `docker-compose.yml`
 
 - [x] Add `MANAGEMENT_SERVER_PORT=${MANAGEMENT_SERVER_PORT:-8081}` to the dev app environment.
-- [x] Publish the dev management port on loopback only, using host port `8082`.
+- [x] Keep the dev management port private on Docker networking and expose it through `eod-app-dev:8081` on the shared `eod-network-dev` network.
 - [x] Validate with `docker compose -f docker-compose.yml config`.
 
 ### Task 2: Let Production Monitoring Reach Host-Published Dev Targets
@@ -26,7 +26,7 @@
 **Files:**
 - Modify: `docker-compose.prod.yml`
 
-- [x] Add `extra_hosts: ["host.docker.internal:host-gateway"]` to production Prometheus.
+- [x] Attach production Prometheus to the shared external `eod-network-dev` network.
 - [x] Add a lightweight `mysqld-exporter-dev` service to production compose.
 - [x] Mount dev app and MySQL log volumes into production Alloy as read-only external volumes.
 - [x] Declare the dev log volumes as external named volumes.
@@ -40,7 +40,7 @@
 - Modify: `monitoring/prometheus/prometheus.yml`
 
 - [x] Add `env="prod"` to existing production scrape targets.
-- [x] Add a dev app scrape target for `host.docker.internal:8082`.
+- [x] Add a dev app scrape target for `eod-app-dev:8081`.
 - [x] Add a dev MySQL scrape target for `mysqld-exporter-dev:9104`.
 - [x] Keep host/container metrics central and label them as `env="shared"`.
 - [x] Validate Prometheus YAML parsing.

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -16,9 +16,9 @@ In the normal same-LXC deployment:
 
 - Production runs the only Prometheus, Grafana, Loki, Alloy, Node Exporter, and cAdvisor stack.
 - Dev runs `app` and `mysql` by default.
-- Dev app metrics are exposed only on loopback as `127.0.0.1:8082`, forwarded to the app management port `8081`.
-- Production Prometheus scrapes dev app metrics through `host.docker.internal:8082`.
-- Production runs `mysqld-exporter-dev`, which connects to dev MySQL through `host.docker.internal:3306`.
+- Dev app metrics stay inside Docker and are scraped over the shared `eod-network-dev` network from `eod-app-dev:8081`.
+- Production Prometheus joins `eod-network-dev` and scrapes dev app metrics from `eod-app-dev:8081`.
+- Production runs `mysqld-exporter-dev`, which joins `eod-network-dev` and connects to dev MySQL at `eod-mysql-dev:3306`.
 - Production Alloy tails both prod and dev log volumes and labels entries with `env="prod"` or `env="dev"`.
 
 This keeps dev visible while avoiding a second Prometheus, Grafana, Loki, Alloy, Node Exporter, and cAdvisor stack during normal deployments.
@@ -42,7 +42,7 @@ Production deployment requires the dev MySQL credentials in:
 - `DEV_MYSQL_USER`
 - `DEV_MYSQL_PASSWORD`
 
-The GitHub production CD workflow fills these from the existing dev database secrets.
+The GitHub production and dev CD workflows ensure the shared external Docker network `eod-network-dev` exists before Compose runs. The production CD workflow fills these from the existing dev database secrets.
 
 ## Required production environment variables
 

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -89,6 +89,8 @@ Dashboard files:
 - `monitoring/grafana/dashboards/eod-infrastructure.json`: server, container, MySQL, and availability metrics
 - `monitoring/grafana/dashboards/eod-jvm.json`: JVM memory, GC, threads, and classes
 - `monitoring/grafana/dashboards/eod-domain-metrics.json`: EOD business/domain metrics
+- `monitoring/grafana/dashboards/eod-dev-monitoring.json`: dev-only app, MySQL, JVM, and container metrics
+- `monitoring/grafana/dashboards/eod-logs.json`: prod/dev application and MySQL logs from Loki
 
 Application, JVM, and domain dashboards include an `env` variable so prod and dev metrics can be viewed separately from the same Grafana instance.
 
@@ -125,6 +127,8 @@ Direct LogQL check:
 {service_name="eod-backend", server="eod-prod-01"}
 {service_name="eod-backend", env="dev"}
 ```
+
+Grafana Logs Drilldown is available from `Drilldown > Logs` in Grafana 12. The `EOD Logs` dashboard also includes a direct link to `/a/grafana-lokiexplore-app` and fixed prod/dev Loki panels so logs remain visible even when the Drilldown navigation is not obvious.
 
 Operational checks:
 

--- a/monitoring/grafana/dashboards/eod-dev-monitoring.json
+++ b/monitoring/grafana/dashboards/eod-dev-monitoring.json
@@ -1,0 +1,643 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "text": "DOWN"
+                },
+                "1": {
+                  "color": "green",
+                  "text": "UP"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "up{job=\"eod-app-dev\"}",
+          "legendFormat": "dev app",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Dev App Metrics Target",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "text": "DOWN"
+                },
+                "1": {
+                  "color": "green",
+                  "text": "UP"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "mysql_up{job=\"mysql-dev\"}",
+          "legendFormat": "dev mysql",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Dev MySQL Target",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(http_server_requests_seconds_count{application=\"eod\",env=\"dev\",uri!=\"UNKNOWN\"}[5m]))",
+          "legendFormat": "requests",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Dev Request Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_requests_seconds_bucket{application=\"eod\",env=\"dev\",uri!=\"UNKNOWN\"}[5m])))",
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Dev HTTP p95 Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "100 * sum(jvm_memory_used_bytes{application=\"eod\",env=\"dev\",area=\"heap\"}) / clamp_min(sum(jvm_memory_max_bytes{application=\"eod\",env=\"dev\",area=\"heap\"}), 1)",
+          "legendFormat": "heap",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Dev JVM Heap Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (name) (container_memory_working_set_bytes{job=\"cadvisor\",name=~\".*eod.*dev.*\"})",
+          "legendFormat": "{{name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Dev Container Memory",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 14
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (name) (rate(container_cpu_usage_seconds_total{job=\"cadvisor\",name=~\".*eod.*dev.*\"}[5m]))",
+          "legendFormat": "{{name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Dev Container CPU",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "refresh": "30s",
+  "schemaVersion": 42,
+  "tags": [
+    "eod",
+    "dev",
+    "prometheus"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "EOD Dev Monitoring",
+  "uid": "eod-dev-monitoring",
+  "version": 1
+}

--- a/monitoring/grafana/dashboards/eod-logs.json
+++ b/monitoring/grafana/dashboards/eod-logs.json
@@ -1,0 +1,242 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Open Logs Drilldown",
+      "tooltip": "Open Grafana Logs Drilldown",
+      "type": "link",
+      "url": "/a/grafana-lokiexplore-app"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Open Explore",
+      "tooltip": "Open Grafana Explore",
+      "type": "link",
+      "url": "/explore?schemaVersion=1&panes=%7B%22eodLogs%22:%7B%22datasource%22:%22loki%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%7Bservice_name%3D%5C%22eod-backend%5C%22%7D%22%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D%7D"
+    }
+  ],
+  "panels": [
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "direction": "backward",
+          "editorMode": "code",
+          "expr": "{service_name=\"eod-backend\", env=\"prod\"}",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Prod App Logs",
+      "type": "logs"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "direction": "backward",
+          "editorMode": "code",
+          "expr": "{service_name=\"eod-backend\", env=\"dev\"}",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Dev App Logs",
+      "type": "logs"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "direction": "backward",
+          "editorMode": "code",
+          "expr": "{service_name=\"mysql\", env=\"prod\"}",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Prod MySQL Logs",
+      "type": "logs"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "direction": "backward",
+          "editorMode": "code",
+          "expr": "{service_name=\"mysql\", env=\"dev\"}",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Dev MySQL Logs",
+      "type": "logs"
+    }
+  ],
+  "preload": false,
+  "refresh": "30s",
+  "schemaVersion": 42,
+  "tags": [
+    "eod",
+    "logs",
+    "loki"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "EOD Logs",
+  "uid": "eod-logs",
+  "version": 1
+}

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -23,7 +23,7 @@ scrape_configs:
   - job_name: "eod-app-dev"
     metrics_path: /actuator/prometheus
     static_configs:
-      - targets: ["host.docker.internal:8082"]
+      - targets: ["eod-app-dev:8081"]
         labels:
           application: eod
           runtime: docker


### PR DESCRIPTION
## 요약
- prod Prometheus가 dev 앱을 host loopback 포트로 scrape하던 방식을 제거했습니다.
- prod Prometheus, blackbox-exporter, dev MySQL exporter를 공유 Docker network(`eod-network-dev`)에 붙여 dev app/MySQL을 내부 DNS로 직접 수집합니다.
- Grafana dashboard provisioning을 파일 구조 기반 폴더로 바꿔 `prod`, `dev`, `logs` 폴더를 분리했습니다.
- dev 폴더에 Overview/JVM/Domain/Infrastructure와 dev-only monitoring dashboard를 복구했습니다.
- Logs Drilldown에서 prod/dev 서비스가 분리되어 보이도록 Loki `service_name`을 `eod-backend-prod`, `eod-backend-dev`, `mysql-prod`, `mysql-dev`로 나눴습니다.

## 원인
`host.docker.internal:8082`는 dev app이 살아 있어도 Linux/LXC에서 host loopback 바인딩 포트에 접근하지 못해 `EodDevAppDown`이 발생할 수 있습니다. 또한 기존 Grafana provisioning은 단일 `EOD` 폴더라 prod/dev 대시보드가 명확히 분리되지 않았습니다.

## 테스트
- [x] `docker compose -f docker-compose.yml config`
- [x] `docker compose -f docker-compose.yml config --services`
- [x] `docker compose -f docker-compose.prod.yml config`
- [x] workflow/prometheus/alert/dashboard provisioning YAML 파싱
- [x] Grafana dashboard JSON 파싱
- [x] `git diff --check`

Follow-up to #289