### PR TITLE
feat: 모바일 인증 플로우 및 개발 로그인 추가

### DIFF
--- a/src/main/java/com/eod/eod/domain/auth/application/MobileOAuthStateService.java
+++ b/src/main/java/com/eod/eod/domain/auth/application/MobileOAuthStateService.java
@@ -3,10 +3,13 @@ package com.eod.eod.domain.auth.application;
 import com.eod.eod.domain.auth.infrastructure.MobileOAuthStateRepository;
 import com.eod.eod.domain.auth.model.MobileOAuthState;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -17,6 +20,9 @@ public class MobileOAuthStateService {
     private static final long STATE_TTL_MINUTES = 5;
 
     private final MobileOAuthStateRepository mobileOAuthStateRepository;
+
+    @Value("${mobile.oauth.allowed-redirect-uris:eodi://auth/callback,eodi-dev://auth/callback}")
+    private String allowedRedirectUris;
 
     public void save(String state, String redirectUri) {
         validateRedirectUri(redirectUri);
@@ -46,7 +52,8 @@ public class MobileOAuthStateService {
         if (redirectUri == null || redirectUri.isBlank()) {
             throw new IllegalArgumentException("모바일 redirectUri가 필요합니다.");
         }
-        if (!redirectUri.startsWith("eodi://") && !redirectUri.startsWith("eodi-dev://")) {
+        List<String> allowed = Arrays.asList(allowedRedirectUris.split(","));
+        if (!allowed.contains(redirectUri)) {
             throw new IllegalArgumentException("허용되지 않은 모바일 redirectUri입니다.");
         }
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -37,6 +37,9 @@ external.server.image-upload-endpoint=${EXTERNAL_SERVER_IMAGE_UPLOAD_ENDPOINT}
 frontend.base-url=${FRONTEND_BASE_URL:http://localhost:3000}
 frontend.oauth-callback-path=/auth/callback
 
+# Mobile OAuth Configuration
+mobile.oauth.allowed-redirect-uris=eodi://auth/callback,eodi-dev://auth/callback
+
 # Logging Configuration (for debugging)
 logging.level.com.eod.eod.common.jwt=DEBUG
 logging.level.org.springframework.security=DEBUG


### PR DESCRIPTION
## Summary

- 모바일 앱 BSM OAuth 플로우 구현 (oneTimeToken 기반 안전한 토큰 교환)
- 개발 환경 전용 dev-login 엔드포인트 추가 (dev/test 프로필)
- 모바일 redirect URI 설정 기반 관리 (`eodi://auth/callback`, `eodi-dev://auth/callback`)
- 모바일 토큰 갱신 엔드포인트 추가 (`/auth/mobile/refresh`)

## 모바일 인증 플로우

```
GET /auth/mobile/bsm/authorize?redirectUri=eodi://auth/callback
→ BSM 로그인 페이지
→ deep link: eodi://auth/callback?oneTimeToken=ABC

POST /auth/mobile/exchange {"oneTimeToken": "ABC"}
→ { accessToken, refreshToken, tokenType, user }
```

## 보안

- oneTimeToken: TTL 5분, 일회용 (토큰이 URL에 직접 노출 안 됨)
- redirect URI: allowlist 기반 정확한 매칭 검증

## Test plan

- [ ] `POST /auth/dev-login` 으로 dev 환경 로그인 확인
- [ ] `GET /auth/mobile/bsm/authorize?redirectUri=eodi://auth/callback` 으로 BSM OAuth URL 확인
- [ ] oneTimeToken exchange 후 accessToken + refreshToken 수신 확인
- [ ] 허용되지 않은 redirectUri 거절 확인