### PR TITLE
fix: Docker Buildx 빌더 부팅 시 Docker Hub 타임아웃 수정

### DIFF
--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -52,6 +52,10 @@ jobs:
 
     - name: Docker Buildx 설정
       uses: docker/setup-buildx-action@v3
+      with:
+        buildkitd-config-inline: |
+          [registry."docker.io"]
+            mirrors = ["mirror.gcr.io"]
 
     - name: GitHub Container Registry 로그인
       uses: docker/login-action@v3

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -46,6 +46,10 @@ jobs:
 
     - name: Docker Buildx 설정
       uses: docker/setup-buildx-action@v3
+      with:
+        buildkitd-config-inline: |
+          [registry."docker.io"]
+            mirrors = ["mirror.gcr.io"]
 
     - name: GitHub Container Registry 로그인
       uses: docker/login-action@v3


### PR DESCRIPTION
## Summary

- `setup-buildx-action`이 `moby/buildkit` 이미지를 Docker Hub에서 pull 시 간헐적 타임아웃 발생
- Google의 Docker Hub 미러(`mirror.gcr.io`) 설정으로 해결
- `cd.yml`, `cd-prod.yml` 모두 적용

## 원인

```
Error: ERROR: Error response from daemon: Get "https://registry-1.docker.io/v2/": context deadline exceeded
```

`docker-container` driver가 buildkit 이미지를 `registry-1.docker.io`에서 pull 시도 → GitHub Actions 환경에서 간헐적 연결 실패

## Test plan

- [ ] CI 워크플로우 정상 실행 확인
- [ ] Docker Buildx 설정 단계 통과 확인