### PR TITLE
fix: 모바일 BSM 로그인 쿠키 기반 redirect URI 복원

### DIFF
--- a/src/main/java/com/eod/eod/domain/auth/application/MobileOAuthStateService.java
+++ b/src/main/java/com/eod/eod/domain/auth/application/MobileOAuthStateService.java
@@ -48,7 +48,7 @@ public class MobileOAuthStateService {
                 });
     }
 
-    private void validateRedirectUri(String redirectUri) {
+    public void validateRedirectUri(String redirectUri) {
         if (redirectUri == null || redirectUri.isBlank()) {
             throw new IllegalArgumentException("모바일 redirectUri가 필요합니다.");
         }

--- a/src/main/java/com/eod/eod/domain/auth/presentation/BsmOAuthCallbackController.java
+++ b/src/main/java/com/eod/eod/domain/auth/presentation/BsmOAuthCallbackController.java
@@ -66,6 +66,12 @@ public class BsmOAuthCallbackController {
         String mobileRedirectUri = null;
         try {
             mobileRedirectUri = mobileOAuthStateService.consumeRedirectUri(state).orElse(null);
+            if (mobileRedirectUri == null) {
+                mobileRedirectUri = cookieUtil.getCookie(request, MobileAuthController.MOBILE_REDIRECT_COOKIE)
+                        .map(Cookie::getValue)
+                        .orElse(null);
+            }
+            cookieUtil.deleteCookie(response, MobileAuthController.MOBILE_REDIRECT_COOKIE, CookieUtil.SameSitePolicy.LAX);
             String discordIdFromState = discordOAuthStateService.consumeDiscordId(state).orElse(null);
             String discordIdFromCookie = cookieUtil.getCookie(request, DISCORD_ID_COOKIE_NAME)
                     .map(Cookie::getValue)

--- a/src/main/java/com/eod/eod/domain/auth/presentation/MobileAuthController.java
+++ b/src/main/java/com/eod/eod/domain/auth/presentation/MobileAuthController.java
@@ -1,5 +1,6 @@
 package com.eod.eod.domain.auth.presentation;
 
+import com.eod.eod.common.util.CookieUtil;
 import com.eod.eod.domain.auth.application.AuthService;
 import com.eod.eod.domain.auth.application.BsmOAuthService;
 import com.eod.eod.domain.auth.application.MobileAuthTokenService;
@@ -11,6 +12,7 @@ import com.eod.eod.domain.auth.presentation.dto.response.AuthUserResponse;
 import com.eod.eod.domain.auth.presentation.dto.response.BsmAuthorizeUrlResponse;
 import com.eod.eod.domain.auth.presentation.dto.response.MobileTokenResponse;
 import com.eod.eod.domain.user.model.User;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -23,6 +25,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.io.IOException;
 import java.security.SecureRandom;
 import java.util.Base64;
 
@@ -35,7 +38,21 @@ public class MobileAuthController {
     private final MobileOAuthStateService mobileOAuthStateService;
     private final MobileAuthTokenService mobileAuthTokenService;
     private final AuthService authService;
+    private final CookieUtil cookieUtil;
     private final SecureRandom secureRandom = new SecureRandom();
+
+    static final String MOBILE_REDIRECT_COOKIE = "bsm_mobile_redirect";
+
+    @GetMapping("/mobile/bsm/start")
+    public void mobileBsmStart(
+            @RequestParam("redirectUri") String redirectUri,
+            HttpServletResponse response
+    ) throws IOException {
+        mobileOAuthStateService.validateRedirectUri(redirectUri);
+        cookieUtil.addTokenCookie(response, MOBILE_REDIRECT_COOKIE, redirectUri,
+                5 * 60 * 1000L, CookieUtil.SameSitePolicy.LAX);
+        response.sendRedirect(bsmOAuthService.buildAuthorizeUrl(generateState()));
+    }
 
     @GetMapping("/mobile/bsm/authorize")
     public ResponseEntity<BsmAuthorizeUrlResponse> authorizeMobileBsm(


### PR DESCRIPTION
## Summary

- BSM이 OAuth 콜백 시 `state` 파라미터를 미반환하는 문제로 모바일 redirect 누락 발생
- 기존: axios로 `/auth/mobile/bsm/authorize` 호출 → BSM URL 받아서 외부 브라우저 오픈 → BSM이 state 없이 콜백 → `mobileRedirectUri = null` → 웹 프론트로 redirect
- 수정: 브라우저가 직접 `/auth/mobile/bsm/start`를 열면 백엔드가 쿠키 설정 후 BSM redirect

## 변경 사항

- `GET /auth/mobile/bsm/start?redirectUri=eodi-dev://auth/callback` 추가
  - redirectUri를 `bsm_mobile_redirect` 쿠키에 저장 (SameSite=LAX, 5분)
  - BSM 로그인 페이지로 직접 redirect
- `BsmOAuthCallbackController`: DB state 조회 실패 시 쿠키 fallback
- `MobileOAuthStateService.validateRedirectUri` public으로 변경

## 앱 수정 사항

```
// 기존 (문제)
GET /auth/mobile/bsm/authorize?redirectUri=eodi-dev://auth/callback
→ URL 받아서 브라우저 열기

// 수정 (브라우저 직접 열기)
브라우저로 /auth/mobile/bsm/start?redirectUri=eodi-dev://auth/callback 열기
```

## Test plan

- [ ] 앱에서 `/auth/mobile/bsm/start` URL을 브라우저로 직접 열기
- [ ] BSM 로그인 완료 후 `eodi-dev://auth/callback?oneTimeToken=xxx` deep link 확인
- [ ] `/auth/mobile/exchange` 호출로 accessToken + refreshToken 수신 확인