### PR TITLE
Separate dev/prod EOD Domain Metrics dashboards by env

### DIFF
--- a/monitoring/grafana/dashboards/dev/eod-domain-metrics.json
+++ b/monitoring/grafana/dashboards/dev/eod-domain-metrics.json
@@ -83,7 +83,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum by (domain, action, result) (increase(eod_business_events_total{env=~\"$env\"}[5m]))",
+          "expr": "sum by (domain, action, result) (increase(eod_business_events_total{env=\"dev\"}[5m]))",
           "legendFormat": "{{ domain }} / {{ action }} / {{ result }}",
           "range": true,
           "refId": "A"
@@ -162,7 +162,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum by (domain, action) (increase(eod_business_events_total{env=~\"$env\",result=\"failure\"}[10m]))",
+          "expr": "sum by (domain, action) (increase(eod_business_events_total{env=\"dev\",result=\"failure\"}[10m]))",
           "legendFormat": "{{ domain }} / {{ action }}",
           "range": true,
           "refId": "A"
@@ -238,7 +238,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "eod_items_current{env=~\"$env\"}",
+          "expr": "eod_items_current{env=\"dev\"}",
           "legendFormat": "{{ status }}",
           "range": true,
           "refId": "A"
@@ -314,7 +314,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "eod_claims_current{env=~\"$env\"}",
+          "expr": "eod_claims_current{env=\"dev\"}",
           "legendFormat": "{{ status }}",
           "range": true,
           "refId": "A"
@@ -381,7 +381,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "eod_reward_eligible_items{env=~\"$env\"}",
+          "expr": "eod_reward_eligible_items{env=\"dev\"}",
           "legendFormat": "eligible",
           "range": true,
           "refId": "A"
@@ -392,7 +392,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "eod_reward_records_current{env=~\"$env\"}",
+          "expr": "eod_reward_records_current{env=\"dev\"}",
           "legendFormat": "records",
           "range": true,
           "refId": "B"
@@ -464,7 +464,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by (le, operation, result) (rate(eod_external_call_seconds_bucket{env=~\"$env\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le, operation, result) (rate(eod_external_call_seconds_bucket{env=\"dev\"}[5m])))",
           "legendFormat": "{{ operation }} / {{ result }}",
           "range": true,
           "refId": "A"
@@ -535,7 +535,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum by (result) (increase(eod_business_events_total{env=~\"$env\",domain=\"image\",action=\"upload\"}[5m]))",
+          "expr": "sum by (result) (increase(eod_business_events_total{env=\"dev\",domain=\"image\",action=\"upload\"}[5m]))",
           "legendFormat": "{{ result }}",
           "range": true,
           "refId": "A"
@@ -606,7 +606,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum by (task, result) (increase(eod_scheduler_runs_total{env=~\"$env\"}[1h]))",
+          "expr": "sum by (task, result) (increase(eod_scheduler_runs_total{env=\"dev\"}[1h]))",
           "legendFormat": "{{ task }} / {{ result }}",
           "range": true,
           "refId": "A"
@@ -617,7 +617,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum by (task) (increase(eod_scheduler_processed_items_sum{env=~\"$env\"}[1h]))",
+          "expr": "sum by (task) (increase(eod_scheduler_processed_items_sum{env=\"dev\"}[1h]))",
           "legendFormat": "{{ task }} processed",
           "range": true,
           "refId": "B"
@@ -637,23 +637,7 @@
   ],
   "templating": {
     "list": [
-      {
-        "name": "env",
-        "type": "query",
-        "datasource": {
-          "type": "prometheus",
-          "uid": "prometheus"
-        },
-        "query": "label_values(up, env)",
-        "refresh": 1,
-        "sort": 1,
-        "current": {
-          "text": "dev",
-          "value": "dev"
-        },
-        "includeAll": false,
-        "multi": false
-      }
+
     ]
   },
   "time": {
@@ -663,7 +647,7 @@
   "timepicker": {
   },
   "timezone": "browser",
-  "title": "EOD Domain Metrics",
+  "title": "EOD Domain Metrics (dev)",
   "uid": "eod-domain-metrics-dev",
   "version": 1
 }

--- a/monitoring/grafana/dashboards/prod/eod-domain-metrics.json
+++ b/monitoring/grafana/dashboards/prod/eod-domain-metrics.json
@@ -77,7 +77,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum by (domain, action, result) (increase(eod_business_events_total{env=~\"$env\"}[5m]))",
+          "expr": "sum by (domain, action, result) (increase(eod_business_events_total{env=\"prod\"}[5m]))",
           "legendFormat": "{{ domain }} / {{ action }} / {{ result }}",
           "range": true,
           "refId": "A"
@@ -152,7 +152,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum by (domain, action) (increase(eod_business_events_total{env=~\"$env\",result=\"failure\"}[10m]))",
+          "expr": "sum by (domain, action) (increase(eod_business_events_total{env=\"prod\",result=\"failure\"}[10m]))",
           "legendFormat": "{{ domain }} / {{ action }}",
           "range": true,
           "refId": "A"
@@ -222,7 +222,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "eod_items_current{env=~\"$env\"}",
+          "expr": "eod_items_current{env=\"prod\"}",
           "legendFormat": "{{ status }}",
           "range": true,
           "refId": "A"
@@ -292,7 +292,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "eod_claims_current{env=~\"$env\"}",
+          "expr": "eod_claims_current{env=\"prod\"}",
           "legendFormat": "{{ status }}",
           "range": true,
           "refId": "A"
@@ -355,7 +355,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "eod_reward_eligible_items{env=~\"$env\"}",
+          "expr": "eod_reward_eligible_items{env=\"prod\"}",
           "legendFormat": "eligible",
           "range": true,
           "refId": "A"
@@ -366,7 +366,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "eod_reward_records_current{env=~\"$env\"}",
+          "expr": "eod_reward_records_current{env=\"prod\"}",
           "legendFormat": "records",
           "range": true,
           "refId": "B"
@@ -434,7 +434,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by (le, operation, result) (rate(eod_external_call_seconds_bucket{env=~\"$env\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le, operation, result) (rate(eod_external_call_seconds_bucket{env=\"prod\"}[5m])))",
           "legendFormat": "{{ operation }} / {{ result }}",
           "range": true,
           "refId": "A"
@@ -501,7 +501,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum by (result) (increase(eod_business_events_total{env=~\"$env\",domain=\"image\",action=\"upload\"}[5m]))",
+          "expr": "sum by (result) (increase(eod_business_events_total{env=\"prod\",domain=\"image\",action=\"upload\"}[5m]))",
           "legendFormat": "{{ result }}",
           "range": true,
           "refId": "A"
@@ -568,7 +568,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum by (task, result) (increase(eod_scheduler_runs_total{env=~\"$env\"}[1h]))",
+          "expr": "sum by (task, result) (increase(eod_scheduler_runs_total{env=\"prod\"}[1h]))",
           "legendFormat": "{{ task }} / {{ result }}",
           "range": true,
           "refId": "A"
@@ -579,7 +579,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum by (task) (increase(eod_scheduler_processed_items_sum{env=~\"$env\"}[1h]))",
+          "expr": "sum by (task) (increase(eod_scheduler_processed_items_sum{env=\"prod\"}[1h]))",
           "legendFormat": "{{ task }} processed",
           "range": true,
           "refId": "B"
@@ -598,7 +598,7 @@
     "domain"
   ],
   "templating": {
-    "list": [{"name":"env","type":"query","datasource":{"type":"prometheus","uid":"prometheus"},"query":"label_values(up, env)","refresh":1,"sort":1,"current":{"text":"prod","value":"prod"},"includeAll":false,"multi":false}]
+    "list": []
   },
   "time": {
     "from": "now-6h",
@@ -606,7 +606,7 @@
   },
   "timepicker": {},
   "timezone": "browser",
-  "title": "EOD Domain Metrics",
+  "title": "EOD Domain Metrics (prod)",
   "uid": "eod-domain-metrics",
   "version": 1
 }


### PR DESCRIPTION
## 배경
단일 Grafana + 단일 Prometheus 구조에서 `EOD Domain Metrics` dev/prod 대시보드가 `$env` 템플릿 변수 기본값만 다른 사실상 동일한 대시보드라 환경 구분이 안 됨.

## 변경
- 모든 패널 쿼리(`expr`)의 `env=~"$env"` → 환경 하드코딩 (dev: `env="dev"`, prod: `env="prod"`), 각 10개
- `templating.list` 의 `env` 쿼리 변수 제거 (빈 배열)
- title 구분: `EOD Domain Metrics (dev)` / `EOD Domain Metrics (prod)` — uid 는 유지
- 기존 `eod-hikaricp`, `eod-infrastructure` 의 env 하드코딩 방식과 일관

## 검증
- 두 파일 모두 유효한 JSON
- `$env` 참조 0개
- dev expr 10개 전부 `env="dev"`, prod expr 10개 전부 `env="prod"`