### PR TITLE
refactor :: CD(dev) 도커 빌드 중복 제거 및 레이어 캐싱 최적화

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,6 +8,10 @@ on:
 env:
   REGISTRY: ghcr.io
 
+concurrency:
+  group: cd-dev-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
@@ -18,24 +22,6 @@ jobs:
     steps:
     - name: 코드 체크아웃
       uses: actions/checkout@v4
-
-    - name: Java 17 설정
-      uses: actions/setup-java@v4
-      with:
-        java-version: '17'
-        distribution: 'temurin'
-        cache: 'gradle'
-
-    - name: Gradle 실행 권한 부여
-      run: chmod +x ./gradlew
-
-    - name: 애플리케이션 JAR 빌드
-      run: ./gradlew bootJar --no-daemon -x test
-
-    - name: QEMU 설정 (ARM64 크로스 컴파일)
-      uses: docker/setup-qemu-action@v3
-      with:
-        platforms: linux/amd64
 
     - name: 이미지 이름 소문자 변환
       id: image_name
@@ -194,8 +180,8 @@ jobs:
           echo "컨테이너 시작 대기 중..."
           sleep 10
 
-          # 사용하지 않는 이미지 정리
-          docker image prune -af
+          # 사용하지 않는 이미지 정리 (24시간 이상 미사용만 — 타 스택 이미지 보호)
+          docker image prune -af --filter "until=24h"
           
     - name: 배포 상태 확인
       uses: appleboy/ssh-action@v1.0.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
 FROM gradle:8.14.3-jdk17 AS builder
 WORKDIR /workspace
 
-COPY gradle gradle
+# 1) 빌드 스크립트만 먼저 복사 → 의존성 레이어 캐시 (소스 변경과 무관)
 COPY gradlew settings.gradle build.gradle ./
-COPY src src
+COPY gradle gradle
+RUN chmod +x gradlew && ./gradlew dependencies --no-daemon
 
-RUN chmod +x gradlew && ./gradlew bootJar --no-daemon
+# 2) 소스 복사 후 빌드 → 소스 변경 시 컴파일만 재실행
+COPY src src
+RUN ./gradlew bootJar --no-daemon
 
 FROM eclipse-temurin:17-jre
 WORKDIR /eod


### PR DESCRIPTION
## 배경
CD(dev)가 Gradle 빌드를 2번 수행 — 워크플로우 `gradlew bootJar` 1회 + Dockerfile multi-stage 내부 1회. 워크플로우 빌드 산출물은 이미지에 안 들어가 통째로 낭비. QEMU도 amd64→amd64라 불필요.

## 변경
**`.github/workflows/cd.yml`**
- 러너 측 `Java 17 설정` · `Gradle 권한` · `gradlew bootJar` 스텝 제거 → Gradle 빌드 2회 → 1회 (Docker multi-stage가 빌드 담당)
- `QEMU 설정` 제거 (amd64 네이티브, 에뮬레이션 불필요)
- `concurrency` 추가 (`cancel-in-progress: true`) — 연속 push 시 배포 레이스 차단
- `docker image prune -af` → `--filter "until=24h"` — 호스트 타 스택 이미지 보호

**`Dockerfile`**
- 빌드 스크립트 먼저 복사 → `gradlew dependencies` 로 의존성 레이어 캐시 분리 → 소스 복사 후 `bootJar`
- 소스 변경 시 의존성 재다운 없이 컴파일만 재실행 (증분 빌드 단축)

## 레지스트리 모델 유지
빌드는 러너에서 1회 → GHCR push → 서버는 pull+up 만. 불변 이미지(테스트=배포 동일물)·롤백 용이·운영 호스트 빌드 부하 없음.

## 검증
- cd.yml YAML 유효
- bootJar/QEMU/setup-java 잔여 참조 0

## 비고
prod(`cd-prod.yml`)는 동일 패턴 별도 PR 예정 (운영이라 분리 적용).