### PR TITLE
refactor :: CD(prod) 도커 빌드 중복 제거 및 prune 범위 제한

### DIFF
--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -14,6 +14,10 @@ on:
 env:
   REGISTRY: ghcr.io
 
+concurrency:
+  group: cd-prod-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
@@ -24,24 +28,6 @@ jobs:
     steps:
     - name: 코드 체크아웃
       uses: actions/checkout@v4
-
-    - name: Java 17 설정
-      uses: actions/setup-java@v4
-      with:
-        java-version: '17'
-        distribution: 'temurin'
-        cache: 'gradle'
-
-    - name: Gradle 실행 권한 부여
-      run: chmod +x ./gradlew
-
-    - name: 애플리케이션 JAR 빌드
-      run: ./gradlew bootJar --no-daemon -x test
-
-    - name: QEMU 설정 (ARM64 크로스 컴파일)
-      uses: docker/setup-qemu-action@v3
-      with:
-        platforms: amd64
 
     - name: 이미지 이름 소문자 변환
       id: image_name
@@ -248,8 +234,8 @@ jobs:
           echo "컨테이너 시작 대기 중..."
           sleep 10
 
-          # 사용하지 않는 이미지 정리
-          docker image prune -af
+          # 사용하지 않는 이미지 정리 (24시간 이상 미사용만 — 타 스택 이미지 보호)
+          docker image prune -af --filter "until=24h"
           
     - name: 배포 상태 확인
       uses: appleboy/ssh-action@v1.0.3


### PR DESCRIPTION
## 배경
dev(#302) 검증 완료 — 워밍 캐시 빌드 빨라짐 확인. 동일 패턴을 운영 CD에 미러링.

## 변경 (`.github/workflows/cd-prod.yml`)
- 러너 측 `Java 17 설정` · `Gradle 권한` · `gradlew bootJar` 제거 → Gradle 빌드 2회 → 1회 (Docker multi-stage가 담당)
- `QEMU 설정` 제거 (amd64 네이티브)
- `concurrency` 추가 — `cancel-in-progress: **false**` (dev와 의도적 차이: 진행 중 운영 배포는 중단 않고 큐잉, 반쪽 배포 방지)
- `docker image prune -af` → `--filter "until=24h"`

Dockerfile 레이어 캐싱 분리는 #302에서 이미 main 반영(공유 파일).

## 검증
- cd-prod.yml YAML 유효
- bootJar/QEMU/setup-java 잔여 0

## 머지 후 주의
prod 캐시 스코프(`eod-prod-build`)는 dev와 별개 → **머지 후 첫 운영 배포는 캐시 콜드**(의존성 풀 다운로드 포함, 1회). 그 다음 배포부터 워밍됨. dev와 동일 양상.

## 미적용 (별건)
- prod `workflow_dispatch` `confirm` 입력이 어디서도 검사 안 됨 + push 트리거라 확인 게이트 무력 → 운영 안전 이슈, 별도 PR 권장.
- prod 배포가 dev 네트워크/볼륨(`eod-network-dev` 등) 생성 — dev/prod 결합.