### PR TITLE
fix :: 중앙 prometheus의 prod app 타겟 모호성 제거 (app→eod-app)

### DIFF
--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -14,7 +14,9 @@ scrape_configs:
   - job_name: "eod-app-docker"
     metrics_path: /actuator/prometheus
     static_configs:
-      - targets: ["app:8081"]
+      # 서비스명 "app"은 dev/prod 양 네트워크에 모두 존재 → 중앙 prometheus가
+      # 두 네트워크에 동시 연결돼 있어 모호하게 resolve됨. 고유 컨테이너명으로 고정.
+      - targets: ["eod-app:8081"]
         labels:
           application: eod
           runtime: docker
@@ -97,7 +99,7 @@ scrape_configs:
       module: [http_2xx]
     static_configs:
       - targets:
-          - "http://app:8080/healthz"
+          - "http://eod-app:8080/healthz"
         labels:
           application: eod
           availability_target: app-internal


### PR DESCRIPTION
## 증상
Grafana의 dev / prod `EOD Domain Metrics` 대시보드에 **같은 값**이 잡힘. 대시보드 env 분리(#301)는 정상이나 소스 데이터가 동일.

## 근본 원인
- prod·dev compose **둘 다 서비스명이 `app`**.
- 중앙 `eod-prometheus`가 `eod-network`(prod) + `eod-network-dev`(dev) **양 네트워크에 동시 연결**.
- 호스트명 `app`이 두 네트워크에 모두 존재 → Docker DNS가 `eod-app`/`eod-app-dev` 중 **모호하게 resolve**.
- 결과: `app:8081`(env=prod) 타겟이 dev 앱을 긁어 **env=prod·env=dev 둘 다 dev 앱 데이터**가 됨 → 값 동일.

DB 공유 아님 확인: `eod-app`→`eod-mysql`, `eod-app-dev`→`eod-mysql-dev` (URL 문자열은 같아도 `mysql`이 네트워크별로 다른 컨테이너로 resolve).

## 변경 (`monitoring/prometheus/prometheus.yml`)
- 모호한 서비스명 `app` → 고유 컨테이너명 `eod-app` 으로 고정 (2곳)
  - job `eod-app-docker` 타겟: `app:8081` → `eod-app:8081`
  - job `blackbox-http` healthz: `http://app:8080/healthz` → `http://eod-app:8080/healthz`
- dev 타겟(`eod-app-dev`)은 이미 고유명이라 변경 없음.

## 적용 (머지 후)
production 브랜치 배포되어야 반영. 또는 prod 서버서 즉시:
```
cd ~/eod/prod
docker compose -f docker-compose.prod.yml exec prometheus kill -HUP 1   # 또는 restart prometheus
```

## 검증
- prometheus.yml YAML 유효
- 모호한 `app:` 참조 0
- 반영 후 `count by(env,instance)(eod_business_events_total)` 에서 env=prod / env=dev instance가 서로 다른지 확인