### PR TITLE
fix :: prod 배포 DISCORD secret을 비접두사로 통일 (PROD_DISCORD_* → DISCORD_*)

### DIFF
--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -129,22 +129,22 @@ jobs:
           FILE_UPLOAD_BASE_URL=${{ secrets.FILE_UPLOAD_BASE_URL }}
           GRAFANA_ADMIN_USER=${{ secrets.PROD_GRAFANA_ADMIN_USER }}
           GRAFANA_ADMIN_PASSWORD=${{ secrets.PROD_GRAFANA_ADMIN_PASSWORD }}
-          DISCORD_WEBHOOK_URL=${{ secrets.PROD_DISCORD_WEBHOOK_URL }}
-          DISCORD_BOT_TOKEN=${{ secrets.PROD_DISCORD_BOT_TOKEN }}
-          DISCORD_GUILD_ID=${{ secrets.PROD_DISCORD_GUILD_ID }}
-          DISCORD_VERIFIED_ROLE_ID=${{ secrets.PROD_DISCORD_VERIFIED_ROLE_ID }}
-          DISCORD_STAFF_NOTIFY_IDS=${{ secrets.PROD_DISCORD_STAFF_NOTIFY_IDS }}
+          DISCORD_WEBHOOK_URL=${{ secrets.DISCORD_WEBHOOK_URL }}
+          DISCORD_BOT_TOKEN=${{ secrets.DISCORD_BOT_TOKEN }}
+          DISCORD_GUILD_ID=${{ secrets.DISCORD_GUILD_ID }}
+          DISCORD_VERIFIED_ROLE_ID=${{ secrets.DISCORD_VERIFIED_ROLE_ID }}
+          DISCORD_STAFF_NOTIFY_IDS=${{ secrets.DISCORD_STAFF_NOTIFY_IDS }}
           DEV_MYSQL_USER=${{ secrets.DB_USERNAME }}
           DEV_MYSQL_PASSWORD=${{ secrets.DB_PASSWORD }}
           EOF
 
           # Alertmanager Discord webhook 설정 파일 생성
-          if [ -z "${{ secrets.PROD_DISCORD_WEBHOOK_URL }}" ]; then
-            echo "❌ PROD_DISCORD_WEBHOOK_URL secret이 설정되지 않았습니다."
+          if [ -z "${{ secrets.DISCORD_WEBHOOK_URL }}" ]; then
+            echo "❌ DISCORD_WEBHOOK_URL secret이 설정되지 않았습니다."
             exit 1
           fi
           mkdir -p monitoring/alertmanager/generated
-          ALERTMANAGER_DISCORD_WEBHOOK_URL='${{ secrets.PROD_DISCORD_WEBHOOK_URL }}' python3 - <<'PY'
+          ALERTMANAGER_DISCORD_WEBHOOK_URL='${{ secrets.DISCORD_WEBHOOK_URL }}' python3 - <<'PY'
           import os
           from pathlib import Path
 


### PR DESCRIPTION
## 배경
prod `.env` 생성 시 `PROD_DISCORD_*` secret 참조. 그런데 `PROD_DISCORD_STAFF_NOTIFY_IDS` secret이 **없어서** prod `.env`에 빈값으로 들어감. 비접두사 `DISCORD_*` secret은 5종 전부 존재.

## 변경 (`.github/workflows/cd-prod.yml`)
`secrets.PROD_DISCORD_*` → `secrets.DISCORD_*` 통일 (7곳: .env 5줄 + webhook 가드 + alertmanager 생성).

| 변수 | 전 | 후 |
|---|---|---|
| DISCORD_WEBHOOK_URL | PROD_DISCORD_WEBHOOK_URL | DISCORD_WEBHOOK_URL |
| DISCORD_BOT_TOKEN | PROD_DISCORD_BOT_TOKEN | DISCORD_BOT_TOKEN |
| DISCORD_GUILD_ID | PROD_DISCORD_GUILD_ID | DISCORD_GUILD_ID |
| DISCORD_VERIFIED_ROLE_ID | PROD_DISCORD_VERIFIED_ROLE_ID | DISCORD_VERIFIED_ROLE_ID |
| DISCORD_STAFF_NOTIFY_IDS | PROD_DISCORD_STAFF_NOTIFY_IDS (**없음**) | DISCORD_STAFF_NOTIFY_IDS (**존재**) |

## 효과
- 빠졌던 `STAFF_NOTIFY_IDS` 채워짐.
- prod/dev가 **같은 DISCORD webhook·bot 공유** (의도된 변경).

## 검증
- cd-prod.yml YAML 유효
- `PROD_DISCORD` 잔여 참조 0